### PR TITLE
chore: simplify rollup config

### DIFF
--- a/contract/rollup.config.mjs
+++ b/contract/rollup.config.mjs
@@ -25,11 +25,6 @@ import { permit as orcaPermit } from './src/orca.proposal.js';
 import { permit as boardAuxPermit } from './src/platform-goals/board-aux.core.js';
 
 // symlinks
-import { nodeResolve } from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
-import json from '@rollup/plugin-json';
-import replace from '@rollup/plugin-replace';
-import typescript from '@rollup/plugin-typescript';
 
 
 /**
@@ -68,23 +63,6 @@ const config1 = ({
       : []),
     moduleToScript(),
     emitPermit({ permit, file: permitFile }),
-    nodeResolve({
-      preferBuiltins: true,
-      mainFields: ['module', 'main'],
-      // moduleDirectories: ['node_modules'],
-      moduleDirectories: ['node_modules'],
-      // modulePaths: ['../../agoric-sdk/packages'],
-      dedupe: ['@agoric/vow', '@agoric/orchestration', '@agoric/vats'],
-    }),
-    commonjs(),
-    // json(),
-    // replace({
-    //   'process.env.NODE_ENV': JSON.stringify('production'),
-    //   preventAssignment: true,
-    // }),
-    typescript({
-      tsconfig: './tsconfig.json',  // Ensure you have a tsconfig.json file in your project root
-    }),
   ],
 });
 

--- a/contract/src/orca.proposal.js
+++ b/contract/src/orca.proposal.js
@@ -7,7 +7,6 @@ import {
 } from './platform-goals/start-contract.js';
 
 import { E } from '@endo/far';
-import { makeTracer } from '@agoric/internal';
 
 
 const { Fail } = assert;


### PR DESCRIPTION
With this tweak, `yarn build:deployer` gives me...

```js
  const {
    // must be supplied by caller or template-replaced
    bundleID = "b1-cfc44b6338eceb9fd63439998109892d0f862197292f28558eb1ef3221a13ad9bc4af82f8a99fdd47b47ea4067fc91fe9b0a338d0def6345dd82d2ee9b1298ea",
  } = config?.options?.[contractName] ?? {};
```
