### PR TITLE
fix: Chain Selector Color

### DIFF
--- a/ui/src/components/Orchestration/ChainSelector.tsx
+++ b/ui/src/components/Orchestration/ChainSelector.tsx
@@ -1,6 +1,6 @@
 const ChainSelector = ({ setSelectedChain }) => (
   <select
-    className="select select-bordered daisyui-focus:ring-blue-500 daisyui-focus:border-blue-500 bg-black-500 daisyui-input-bordered w-full rounded-lg px-4 py-2 text-lg text-white"
+    className="select select-bordered daisyui-focus:ring-blue-500 daisyui-focus:border-blue-500 bg-black-500 daisyui-input-bordered text-blue w-full rounded-lg px-4 py-2"
     onChange={e => setSelectedChain(e.target.value)}
   >
     <option disabled selected>


### PR DESCRIPTION

Chain Selector was invisible in UI in light theme. This is a fix by changing the text color to blue. Tested to work on light and dark themes with Safari/Edge/Chrome on mac.

Also decreased font size to normal to fit the text inside the selector. 