### PR TITLE
feat: add emerynet to network selector

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -28,6 +28,17 @@ function App() {
                 rpc: ['http://localhost:26657'],
               },
             },
+            {
+              testChain: {
+                chainId: 'agoric-emerynet-8', // should be derived from network-config, right?
+                chainName: 'emerynet',
+                iconUrl: 'agoric.svg',
+              },
+              apis: {
+                rest: ['https://emerynet.api.agoric.net'],
+                rpc: ['https://emerynet.rpc.agoric.net'],
+              },
+            },
           ]}
           defaultChainName="agoric-local"
         >


### PR DESCRIPTION
goal:
closes #43 

This is evidently not enough - Keplr still asks to confirm that I want to add a network with a localhost rpc.

The RPC address seems to be hard-coded in places such as...

https://github.com/Agoric/dapp-orchestration-basics/blob/486f4eb6e0586542661420cc5a1c494a2380cc46/ui/src/components/Orchestration/MakeAccount.tsx#L9-L12

cc @LuqiPan 