### PR TITLE
Reduced e2e Makefile command to only run deploy-contract.js 

### DIFF
--- a/contract/Makefile
+++ b/contract/Makefile
@@ -255,27 +255,8 @@ test-orca:
 	yarn test ./test/orca-contract.test.js
 
 
-# todo remove clean install steps after debugging
 e2e:
-	make clean
-	make cleanc
-	yarn cache clean
-	kubectl exec -i agoriclocal-genesis-0 -c validator -- bash -c "yarn cache clean"
-	kubectl exec -i agoriclocal-genesis-0 -c validator -- bash -c "rm -rf -v /root/*"
-# yarn run build:deployer
-	make copy-project  
-	kubectl exec -i agoriclocal-genesis-0 -c validator -- bash -c "cd /root/ ; yarn install"
-	kubectl exec -i agoriclocal-genesis-0 -c validator -- bash -c "cd /root/ ; yarn add @endo/patterns@1.3.0"
-#kubectl exec -i agoriclocal-genesis-0 -c validator -- bash -c "cd /root/ ; yarn add @agoric/orchestration@0.1.1-dev-9c9e5cf.0"
-	kubectl exec -i agoriclocal-genesis-0 -c validator -- bash -c "cd /root/ ; yarn add @agoric/vow@0.1.1-dev-9c9e5cf.0"
-	kubectl exec -i agoriclocal-genesis-0 -c validator -- bash -c "cd /root/ ; yarn add @agoric/async-flow@0.1.1-dev-9c9e5cf.0"
-	kubectl exec -i agoriclocal-genesis-0 -c validator -- bash -c "cd /root/ ; yarn build:deployer"
-
-# yarn node scripts/deploy-contract.js --install /root/src/orca.contract.js --eval /root/src/orca.proposal.js
 	yarn node scripts/deploy-contract.js --install ${PWD}/src/orca.contract.js,${PWD}/src/orca.proposal.js --eval /root/src/orca.proposal.js
-
-# todo: figure out why this sequence # is always off by 1 forcing a retry
-# yarn node script/deploy-contract.js
 
 lint:
 	yarn lint --fix-dry-run --ignore-pattern "*patch*" 


### PR DESCRIPTION
@amessbee 

Note: this PR  doesn't unblock anything, because you can just run this command directly, as per my suggestion earlier.

I removed the unecessary commands in the Makefile `e2e` stage. Hopefully this clarifies whats not needed here for ya. 

As I mentioned all that is needed is this following command:
```console
yarn node scripts/deploy-contract.js --install ${PWD}/src/orca.contract.js,${PWD}/src/orca.proposal.js --eval /root/src/orca.proposal.js
```

You should not see any installation related errors when running this command, as its not installing anything. 

The following error you mentioned is an installation error:
```
error Couldn't find any versions for "@agoric/orchestration" that matches "patch:@agoric/orchestration@npm%3A0.2.0-upgrade-17-dev-ec448b0.0#~/.yarn/patches/@agoric-orchestration-npm-0.2.0-upgrade-17-dev-ec448b0.0-f94046c01d.patch"
command terminated with exit code 1
make: *** [e2e] Error 1
```