### PR TITLE
build: downgrade cosmos-kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "protobufjs@npm:~6.11.2": "patch:protobufjs@npm%3A6.11.4#~/.yarn/patches/protobufjs-npm-6.11.4-af11968b80.patch",
     "protobufjs@npm:^6.11.2": "patch:protobufjs@npm%3A6.11.4#~/.yarn/patches/protobufjs-npm-6.11.4-af11968b80.patch",
     "protobufjs@npm:^6.10.3": "patch:protobufjs@npm%3A6.11.4#~/.yarn/patches/protobufjs-npm-6.11.4-af11968b80.patch",
-    "protobufjs@npm:^7.2.5": "patch:protobufjs@npm%3A6.11.4#~/.yarn/patches/protobufjs-npm-6.11.4-af11968b80.patch"
+    "protobufjs@npm:^7.2.5": "patch:protobufjs@npm%3A6.11.4#~/.yarn/patches/protobufjs-npm-6.11.4-af11968b80.patch",
+    "@hexxagon/feather.js": "npm:@terra-money/feather.js@1.0.3"
   },
   "scripts": {
     "start:ui": "cd ui && yarn dev",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "protobufjs@npm:~6.11.2": "patch:protobufjs@npm%3A6.11.4#~/.yarn/patches/protobufjs-npm-6.11.4-af11968b80.patch",
     "protobufjs@npm:^6.11.2": "patch:protobufjs@npm%3A6.11.4#~/.yarn/patches/protobufjs-npm-6.11.4-af11968b80.patch",
     "protobufjs@npm:^6.10.3": "patch:protobufjs@npm%3A6.11.4#~/.yarn/patches/protobufjs-npm-6.11.4-af11968b80.patch",
-    "protobufjs@npm:^7.2.5": "patch:protobufjs@npm%3A6.11.4#~/.yarn/patches/protobufjs-npm-6.11.4-af11968b80.patch",
-    "@hexxagon/feather.js": "npm:@terra-money/feather.js@1.0.3"
+    "protobufjs@npm:^7.2.5": "patch:protobufjs@npm%3A6.11.4#~/.yarn/patches/protobufjs-npm-6.11.4-af11968b80.patch"
   },
   "scripts": {
     "start:ui": "cd ui && yarn dev",

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,7 +17,7 @@
     "@agoric/react-components": "0.2.1-dev-e6f79e0.0",
     "buffer": "^6.0.3",
     "chain-registry": "1.28.0",
-    "cosmos-kit": "^2.19.0",
+    "cosmos-kit": "^2.8.5",
     "daisyui": "^4.12.10",
     "react": "^18.3.1",
     "react-daisyui": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,18 +1578,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@classic-terra/terra.proto@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@classic-terra/terra.proto@npm:1.1.0"
-  dependencies:
-    "@improbable-eng/grpc-web": "npm:^0.14.1"
-    google-protobuf: "npm:^3.17.3"
-    long: "npm:^4.0.0"
-    protobufjs: "npm:~6.11.2"
-  checksum: 10c0/b285534bf7242286a9780a484d10d901af491bbfad1b3697f7b3439dc824ae7658ad8d2a8c3af179ef772c66a2c3c5d6118b055b0a087bea29e5a98abdfd6072
-  languageName: node
-  linkType: hard
-
 "@coinbase/wallet-sdk@npm:^3.6.6":
   version: 3.7.2
   resolution: "@coinbase/wallet-sdk@npm:3.7.2"
@@ -4735,11 +4723,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hexxagon/feather.js@npm:^1.0.9-beta.8":
-  version: 1.0.11
-  resolution: "@hexxagon/feather.js@npm:1.0.11"
+"@hexxagon/feather.js@npm:@terra-money/feather.js@1.0.3":
+  version: 1.0.3
+  resolution: "@terra-money/feather.js@npm:1.0.3"
   dependencies:
-    "@classic-terra/terra.proto": "npm:^1.1.0"
     "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7"
     "@terra-money/terra.proto": "npm:3.0.5"
     axios: "npm:^0.27.2"
@@ -4754,7 +4741,7 @@ __metadata:
     tmp: "npm:^0.2.1"
     utf-8-validate: "npm:^5.0.5"
     ws: "npm:^7.5.9"
-  checksum: 10c0/912e3133e059b73eb587a47774db29d0299750f762bd7ef8a10a6b7ccd3ba05100d8c9d31c04b67097522ea64883ff864970d69875fb68652f239c54b0ad424b
+  checksum: 10c0/ef64997bd65e08db40f0c717eac403ab76c971870d593fe0a426567b8103893e6cb8f2c8cc6fe268793b4a1f408409d5fdf477f84e2cd9a098151a0b379cf4a2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,25 +1480,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chain-registry/cosmostation@npm:1.66.2":
-  version: 1.66.2
-  resolution: "@chain-registry/cosmostation@npm:1.66.2"
+"@chain-registry/client@npm:^1.49.11":
+  version: 1.53.51
+  resolution: "@chain-registry/client@npm:1.53.51"
   dependencies:
-    "@chain-registry/types": "npm:^0.45.1"
-    "@chain-registry/utils": "npm:^1.46.1"
-    "@cosmostation/extension-client": "npm:0.1.15"
-  checksum: 10c0/6ec2bdfd32b05e93bfef23ee72dd65c2c0a539ae70c5cf22fc7e73602e0172bda1a8343352cf4025e410dfec88aa3abe2a59a76e88fc69f2fe5d867eca9408f9
+    "@chain-registry/types": "npm:^0.50.51"
+    "@chain-registry/utils": "npm:^1.51.51"
+    bfs-path: "npm:^1.0.2"
+    cross-fetch: "npm:^3.1.5"
+  checksum: 10c0/c00db49685e22b295bcc9469cf5117cf7d1ccdfd2c27229236bf503883eec36724e992982da91285428edf0dd33e20d14aae90e4058891a2610cdb7a9f5c7850
   languageName: node
   linkType: hard
 
-"@chain-registry/cosmostation@npm:^1.66.2":
-  version: 1.66.101
-  resolution: "@chain-registry/cosmostation@npm:1.66.101"
+"@chain-registry/cosmostation@npm:1.67.13":
+  version: 1.67.13
+  resolution: "@chain-registry/cosmostation@npm:1.67.13"
   dependencies:
-    "@chain-registry/types": "npm:^0.45.81"
-    "@chain-registry/utils": "npm:^1.46.81"
+    "@chain-registry/types": "npm:^0.46.11"
+    "@chain-registry/utils": "npm:^1.47.11"
     "@cosmostation/extension-client": "npm:0.1.15"
-  checksum: 10c0/ed2932cddd109bc5254027453ae3c474c7eaf868be14981ac3537b8d7dac0c7f13b51d39144c53a19e60ed7f3397bed8e4e31cbdd917fd640dd8c140f63f5d69
+  checksum: 10c0/d9cb615ab21fc868eb02a877f0ccd4744478a65e2993d1d936c84f67a97a036e363e081193ea1e5c712e59cde985112f66b67012230a5d5d5f49466e8fbbcce6
+  languageName: node
+  linkType: hard
+
+"@chain-registry/cosmostation@npm:^1.67.13":
+  version: 1.72.95
+  resolution: "@chain-registry/cosmostation@npm:1.72.95"
+  dependencies:
+    "@chain-registry/types": "npm:^0.50.51"
+    "@chain-registry/utils": "npm:^1.51.51"
+    "@cosmostation/extension-client": "npm:0.1.15"
+  checksum: 10c0/640d16054744466f531f01caed1fa13eb1dee44b01801686e8a8c28ba05211a0aa50018bd6a6fcae972cf332c8ab7fbcce0dff0e8e2bf278ace5a7e63e6da96f
   languageName: node
   linkType: hard
 
@@ -1526,19 +1538,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chain-registry/keplr@npm:^1.69.13":
+  version: 1.74.95
+  resolution: "@chain-registry/keplr@npm:1.74.95"
+  dependencies:
+    "@chain-registry/types": "npm:^0.50.51"
+    "@keplr-wallet/cosmos": "npm:0.12.28"
+    "@keplr-wallet/crypto": "npm:0.12.28"
+    semver: "npm:^7.5.0"
+  checksum: 10c0/7b60b4399f871469314fc8651604b8d4becd9ebb06a72a4c02c3599f8219eb7cbfebd119f492e910320378298ad2096ab07ac0ab277664532804abcd51b81135
+  languageName: node
+  linkType: hard
+
 "@chain-registry/types@npm:0.17.0":
   version: 0.17.0
   resolution: "@chain-registry/types@npm:0.17.0"
   dependencies:
     "@babel/runtime": "npm:^7.21.0"
   checksum: 10c0/e4a32546e350240560b1339a3dcb6426eede1569ba9d17b0d6b5eeacd79fb643f347c21ea7f5ba147185c9ad2e19eea44dff248d8e1bf27e882511398812bfe4
-  languageName: node
-  linkType: hard
-
-"@chain-registry/types@npm:0.45.1":
-  version: 0.45.1
-  resolution: "@chain-registry/types@npm:0.45.1"
-  checksum: 10c0/d2008c36e2b9d5b4dfbeae2e4038b956789cf7a70bff85d936fdb76a34a16609952b8b233bd09c3e93eeb9ccde26a5492230d1f3e450b2a7a7b8474df76835a5
   languageName: node
   linkType: hard
 
@@ -1567,7 +1584,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chain-registry/utils@npm:^1.17.0, @chain-registry/utils@npm:^1.46.1, @chain-registry/utils@npm:^1.46.81":
+"@chain-registry/types@npm:^0.46.11":
+  version: 0.46.15
+  resolution: "@chain-registry/types@npm:0.46.15"
+  checksum: 10c0/11655ead021fcc78f317f682842a73666e080216d22f87be5b9fffa9341130b3e8b8a3b1d2d77ec3c41841af4c1fbdf24af467ef12df552fa2e99fe2eae5f1e1
+  languageName: node
+  linkType: hard
+
+"@chain-registry/types@npm:^0.50.51":
+  version: 0.50.51
+  resolution: "@chain-registry/types@npm:0.50.51"
+  checksum: 10c0/99ffe01e30728d330670d6a6a31a27a89b7f91811c814671bb81923e7bedd70fbc5142c762bde6455b21f7606b0fb62b69b26e5420e75c35f69e477eb0e7f0a9
+  languageName: node
+  linkType: hard
+
+"@chain-registry/utils@npm:^1.17.0, @chain-registry/utils@npm:^1.46.81":
   version: 1.46.81
   resolution: "@chain-registry/utils@npm:1.46.81"
   dependencies:
@@ -1575,6 +1606,17 @@ __metadata:
     bignumber.js: "npm:9.1.2"
     sha.js: "npm:^2.4.11"
   checksum: 10c0/30632124686eeecf56946f5bf4099811768946c1f0ef12f75b67b6f082bd7e3ea79f976245d9da018c77ad8de87364c960d64ea2f915d3a8d7167da455aeeebc
+  languageName: node
+  linkType: hard
+
+"@chain-registry/utils@npm:^1.47.11, @chain-registry/utils@npm:^1.51.51":
+  version: 1.51.51
+  resolution: "@chain-registry/utils@npm:1.51.51"
+  dependencies:
+    "@chain-registry/types": "npm:^0.50.51"
+    bignumber.js: "npm:9.1.2"
+    sha.js: "npm:^2.4.11"
+  checksum: 10c0/ae571942f1feeb8560d11d7d0232fde6d701f01d5d8fe791e22d293d8d87895d64947356c9816697e06e25f2656a5b77d2893632d8dc363e789f32a2e9463d20
   languageName: node
   linkType: hard
 
@@ -2220,70 +2262,70 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmos-kit/cdcwallet-extension@npm:^2.13.2":
-  version: 2.13.2
-  resolution: "@cosmos-kit/cdcwallet-extension@npm:2.13.2"
+"@cosmos-kit/cdcwallet-extension@npm:^2.15.3":
+  version: 2.15.3
+  resolution: "@cosmos-kit/cdcwallet-extension@npm:2.15.3"
   dependencies:
-    "@chain-registry/keplr": "npm:1.68.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
+    "@chain-registry/keplr": "npm:^1.69.13"
+    "@cosmos-kit/core": "npm:^2.15.1"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/2c159f90a568ed1a94495950ddc9d5674249276e803eff784143c2b35986933b95a8a8735d6fcd670070651e8bf3c8de67013cd5f58e62dae95f488bfd1a85d9
+  checksum: 10c0/00047f0f842b3789d10689975c82acc1375cf8bc3048c4a9c24335b2664a50993d18f061b4efcd9cf1f55737f6208e366964352c821833fdcf9125352ac2f0a8
   languageName: node
   linkType: hard
 
-"@cosmos-kit/cdcwallet@npm:^2.13.2":
-  version: 2.13.2
-  resolution: "@cosmos-kit/cdcwallet@npm:2.13.2"
+"@cosmos-kit/cdcwallet@npm:^2.15.3":
+  version: 2.15.3
+  resolution: "@cosmos-kit/cdcwallet@npm:2.15.3"
   dependencies:
-    "@cosmos-kit/cdcwallet-extension": "npm:^2.13.2"
-  checksum: 10c0/d9d0d888a771810356154bc4fbfb1b4530cb97831ce7ff1e35c46a2b388864660dc9e0a7c7b76dff720c0a922645a519877e3f0e69180633f48e06ac0f8a5bf5
+    "@cosmos-kit/cdcwallet-extension": "npm:^2.15.3"
+  checksum: 10c0/2f7ff18fbb042598fc2a02c5125ad0e831e4d8fc94aecfbcf08fb2d620d156dc85195a8d2548988eda44a97c80cbf3d9e2edb07ddd442640d092e41f0aee36c1
   languageName: node
   linkType: hard
 
-"@cosmos-kit/coin98-extension@npm:^2.12.2":
-  version: 2.12.2
-  resolution: "@cosmos-kit/coin98-extension@npm:2.12.2"
+"@cosmos-kit/coin98-extension@npm:^2.14.3":
+  version: 2.14.3
+  resolution: "@cosmos-kit/coin98-extension@npm:2.14.3"
   dependencies:
-    "@chain-registry/keplr": "npm:1.68.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
+    "@chain-registry/keplr": "npm:^1.69.13"
+    "@cosmos-kit/core": "npm:^2.15.1"
     cosmjs-types: "npm:>=0.9.0"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/1a1423dd45288f77b7cb615342fa9750a11cfd741d5047ef6737d258d6af115f5e2ef6eac4cc41b5ed7599db7d21d02fb7682e02b0f1b533625714a8316794da
+  checksum: 10c0/9cff3630732c934aff0f40a3c5c068a9b0ee8cfc2d1b7033d97858280b5ca2d9a51732117e606cb6b3d6aaa6ab0f886f2ddcf0e63b27305fccf75a08e20ca2a7
   languageName: node
   linkType: hard
 
-"@cosmos-kit/coin98@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/coin98@npm:2.11.2"
+"@cosmos-kit/coin98@npm:^2.13.3":
+  version: 2.13.3
+  resolution: "@cosmos-kit/coin98@npm:2.13.3"
   dependencies:
-    "@cosmos-kit/coin98-extension": "npm:^2.12.2"
-  checksum: 10c0/7b9cf76b26e816743e17011eb3f1780bf9b49cbcdb7a8d2534322189c4e8e785212fe20794903ffbcfd11c532ab1828463d2527bba85b4a27f921bb8f63e1c9a
+    "@cosmos-kit/coin98-extension": "npm:^2.14.3"
+  checksum: 10c0/14cda5f82fb53020618e5aafbe10e2233d696c51cd34b8b4216874f3275ea14acf2026e3e8d6fc32078dfb95e30011141395358a03988a4e180a13985ff10e21
   languageName: node
   linkType: hard
 
-"@cosmos-kit/compass-extension@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/compass-extension@npm:2.11.2"
+"@cosmos-kit/compass-extension@npm:^2.13.3":
+  version: 2.13.3
+  resolution: "@cosmos-kit/compass-extension@npm:2.13.3"
   dependencies:
-    "@chain-registry/keplr": "npm:1.68.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
+    "@chain-registry/keplr": "npm:^1.69.13"
+    "@cosmos-kit/core": "npm:^2.15.1"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/663087e375619b271e0a0c41e45679c5e45ba17d0c6bd12a354316471ad186454583d15ff5076c106660b9becd723ed6ad3645a502352309a453053955cea8cf
+  checksum: 10c0/78bc0c3a8eaa0bb6ff0efc3ca73563958313bcb275b9852d80361d23a952eba3f200bfc89eae141c35936d84b1d156286d62642e018965e7ba9871cf8d8a2faf
   languageName: node
   linkType: hard
 
-"@cosmos-kit/compass@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/compass@npm:2.11.2"
+"@cosmos-kit/compass@npm:^2.13.3":
+  version: 2.13.3
+  resolution: "@cosmos-kit/compass@npm:2.13.3"
   dependencies:
-    "@cosmos-kit/compass-extension": "npm:^2.11.2"
-  checksum: 10c0/35fe8f1cfe889425cfd85ed41e8299839677a12a4fe3228b78cf2cf5e9389990aeb737b7cea3c9fb7b316a72abfa4bcd441fe07a4065f14e7f59b96d108b7ffe
+    "@cosmos-kit/compass-extension": "npm:^2.13.3"
+  checksum: 10c0/3cf47901549d400bbe0ce79dbe8805da67c3ad8abd1eff989bb318c79bf5b64baf46b00ae43f2b724626318c9eca4d118ab92847d78cc34a604b09ee73a13a52
   languageName: node
   linkType: hard
 
@@ -2306,7 +2348,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmos-kit/core@npm:^2.13.1, @cosmos-kit/core@npm:^2.8.9":
+"@cosmos-kit/core@npm:^2.15.1":
+  version: 2.15.1
+  resolution: "@cosmos-kit/core@npm:2.15.1"
+  dependencies:
+    "@chain-registry/client": "npm:^1.49.11"
+    "@chain-registry/keplr": "npm:^1.69.13"
+    "@chain-registry/types": "npm:^0.46.11"
+    "@cosmjs/amino": "npm:^0.32.3"
+    "@cosmjs/cosmwasm-stargate": "npm:^0.32.3"
+    "@cosmjs/proto-signing": "npm:^0.32.3"
+    "@cosmjs/stargate": "npm:^0.32.3"
+    "@dao-dao/cosmiframe": "npm:^1.0.0-rc.1"
+    "@walletconnect/types": "npm:2.11.0"
+    bowser: "npm:2.11.0"
+    cosmjs-types: "npm:^0.9.0"
+    events: "npm:3.3.0"
+    nock: "npm:13.5.4"
+    uuid: "npm:^9.0.1"
+  checksum: 10c0/922b0608742e3a3822b33945f29ba0ea779a47ecbe3a9679fc45506d4d17d5ee9788791480d87c00e5a018c48b227866e0e8e0d2554c38f84d6b4e8bd9820c0b
+  languageName: node
+  linkType: hard
+
+"@cosmos-kit/core@npm:^2.8.9":
   version: 2.13.1
   resolution: "@cosmos-kit/core@npm:2.13.1"
   dependencies:
@@ -2328,292 +2392,282 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmos-kit/cosmostation-extension@npm:^2.13.0":
-  version: 2.13.0
-  resolution: "@cosmos-kit/cosmostation-extension@npm:2.13.0"
+"@cosmos-kit/cosmostation-extension@npm:^2.15.2":
+  version: 2.15.2
+  resolution: "@cosmos-kit/cosmostation-extension@npm:2.15.2"
   dependencies:
-    "@chain-registry/cosmostation": "npm:^1.66.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
+    "@chain-registry/cosmostation": "npm:^1.67.13"
+    "@cosmos-kit/core": "npm:^2.15.1"
     cosmjs-types: "npm:^0.9.0"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/af0e4e250041a6ea75c208c791f20a2d8d78bd5d11fe6f3264ae03c340a2d1ef3133dff9fd997c0f08e8402f4b658c3b22c73a36f2fe48119b7329617ec1919f
+  checksum: 10c0/49ec82b9b882c477765f1656ed17a43ebb7331018ba92b121e1d7b69a936775afd4bc0b93bbedd2bc2642f1dfc912b85fa3b9ffa19eeb3c231a1d54db0800afc
   languageName: node
   linkType: hard
 
-"@cosmos-kit/cosmostation-mobile@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/cosmostation-mobile@npm:2.11.2"
+"@cosmos-kit/cosmostation-mobile@npm:^2.13.2":
+  version: 2.13.2
+  resolution: "@cosmos-kit/cosmostation-mobile@npm:2.13.2"
   dependencies:
-    "@chain-registry/cosmostation": "npm:1.66.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
-    "@cosmos-kit/walletconnect": "npm:^2.10.1"
-  checksum: 10c0/a52d1ae62b1797b809251715e3c88c74646053e34f9e9b96d9d170c252ecf18118bf55e58ca59a8fd50fa7503cd5aebd5a59546de1dabfa618f09733ff3c5439
+    "@chain-registry/cosmostation": "npm:1.67.13"
+    "@cosmos-kit/core": "npm:^2.15.1"
+    "@cosmos-kit/walletconnect": "npm:^2.12.1"
+  checksum: 10c0/157f334c6aace0a2a9396a619884ac198f8b1004c166e873c4f2de96fbbaf13b77f190cc3da3f6da778c20f5529b4ca26f718b21cc591ef5205eee5daee38e66
   languageName: node
   linkType: hard
 
-"@cosmos-kit/cosmostation@npm:^2.12.0":
-  version: 2.12.0
-  resolution: "@cosmos-kit/cosmostation@npm:2.12.0"
+"@cosmos-kit/cosmostation@npm:^2.14.2":
+  version: 2.14.2
+  resolution: "@cosmos-kit/cosmostation@npm:2.14.2"
   dependencies:
-    "@cosmos-kit/cosmostation-extension": "npm:^2.13.0"
-    "@cosmos-kit/cosmostation-mobile": "npm:^2.11.2"
-  checksum: 10c0/dd1ae4a8968557c16fc2c07c8e58df7d8ed22e68a3ae728f06d18eddb72eafccae00896fd574eb839ef44e0fcae159d0b5c75b3941b71013c4b372e57dc9e2e2
+    "@cosmos-kit/cosmostation-extension": "npm:^2.15.2"
+    "@cosmos-kit/cosmostation-mobile": "npm:^2.13.2"
+  checksum: 10c0/eee4cb32432f78cf313c3a0ee35371e436bf34480cf15dfcd5666d7e769e6a85633daadd265cb86f2e2e844cf1c50037693e58821c37ccb5afe5fa70f59ab122
   languageName: node
   linkType: hard
 
-"@cosmos-kit/exodus-extension@npm:^2.10.2":
-  version: 2.10.2
-  resolution: "@cosmos-kit/exodus-extension@npm:2.10.2"
+"@cosmos-kit/ctrl-extension@npm:^2.14.2":
+  version: 2.14.2
+  resolution: "@cosmos-kit/ctrl-extension@npm:2.14.2"
   dependencies:
-    "@cosmos-kit/core": "npm:^2.13.1"
+    "@cosmos-kit/core": "npm:^2.15.1"
+  peerDependencies:
+    "@cosmjs/amino": ">=0.32.3"
+    "@cosmjs/proto-signing": ">=0.32.3"
+  checksum: 10c0/97beb17c82dc313229be5f4d08ca728336f269c2c44abe120a449e8fdf85574b1275548a142ccab0a59eeee1148a6072ecfbc9096e613d38cc473e01283c1702
+  languageName: node
+  linkType: hard
+
+"@cosmos-kit/ctrl@npm:^2.13.2":
+  version: 2.13.2
+  resolution: "@cosmos-kit/ctrl@npm:2.13.2"
+  dependencies:
+    "@cosmos-kit/ctrl-extension": "npm:^2.14.2"
+  checksum: 10c0/0e4a08bf04ace8b7c58d3c543026b2fef2ad087357e98e90c44fc3363f833446188e402617154622ada2b2aa51042fedbc3ca637f79035d7ba6d8edb0656765e
+  languageName: node
+  linkType: hard
+
+"@cosmos-kit/exodus-extension@npm:^2.12.2":
+  version: 2.12.2
+  resolution: "@cosmos-kit/exodus-extension@npm:2.12.2"
+  dependencies:
+    "@cosmos-kit/core": "npm:^2.15.1"
     react-icons: "npm:4.4.0"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/a6b7716472fd28a3172a99471d8e8f9c557344f0c9ea36e5e031f2424e9674ba5de16998fcb2bd0b72d5037a93bfae662f687d83f04268647042462707de3c6c
+  checksum: 10c0/19aacb7c1c55c48626ca704962619adfd435cb09ec84887f598aa0a368d4389dc6666a747b9a0655b43632fe2f386b706bec96c56811e9af84503640ac349098
   languageName: node
   linkType: hard
 
-"@cosmos-kit/exodus@npm:^2.10.2":
-  version: 2.10.2
-  resolution: "@cosmos-kit/exodus@npm:2.10.2"
-  dependencies:
-    "@cosmos-kit/exodus-extension": "npm:^2.10.2"
-  checksum: 10c0/5733c78fbf176824881124b97a0404d95faf366d39b13fa4e3eecc1119edc9932f7f1469bd2c66d7f7c41d28d70392bf66deaebc76ba3c0a6f353f6e7d557502
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/fin-extension@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/fin-extension@npm:2.11.2"
-  dependencies:
-    "@chain-registry/keplr": "npm:1.68.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
-  peerDependencies:
-    "@cosmjs/amino": ">=0.32.3"
-    "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/314968c6c2c637fbc4d7785dd3fb2e12203ea9566583f7b8bc101833c59497d9ce3bd0216236b5dbcbb787d0492b80f9e501bd54d898f5a150b8f76fa46d4537
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/fin@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/fin@npm:2.11.2"
-  dependencies:
-    "@cosmos-kit/fin-extension": "npm:^2.11.2"
-  checksum: 10c0/f24e13e27baf5caf37f1bd18474dad022f4b987fd0213974c7fdd4510cfce3eab428d69ed73ed134115f3b91aa208ec29451ab92f71146660a510ea92f08a025
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/frontier-extension@npm:^2.10.2":
-  version: 2.10.2
-  resolution: "@cosmos-kit/frontier-extension@npm:2.10.2"
-  dependencies:
-    "@cosmos-kit/core": "npm:^2.13.1"
-  peerDependencies:
-    "@cosmjs/amino": ">=0.32.3"
-    "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/ae6ceeaaded9367d0a46932d534c051c0ec8d49a76dd80144c61f8de5d9ddbf3cdfe03b682a2ea66756ce93e46e2e1142251a31174ffbc45f688a1aff9cc3155
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/frontier@npm:^2.10.2":
-  version: 2.10.2
-  resolution: "@cosmos-kit/frontier@npm:2.10.2"
-  dependencies:
-    "@cosmos-kit/frontier-extension": "npm:^2.10.2"
-  checksum: 10c0/617ed26dd6cecf960b511180f9a15b4a1360ae7293467ea165b25a4ce89e192d98dc47d77d4086af79abd7ca682a26d2311ac61c3c3cf164b0007a87bca994f5
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/galaxy-station-extension@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/galaxy-station-extension@npm:2.11.2"
-  dependencies:
-    "@chain-registry/types": "npm:0.45.1"
-    "@cosmos-kit/core": "npm:^2.13.1"
-    "@hexxagon/feather.js": "npm:^1.0.9-beta.8"
-    "@hexxagon/station-connector": "npm:^1.0.17"
-  peerDependencies:
-    "@cosmjs/amino": ">=0.32.3"
-    "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/6c481b17504935ed589583d18cda708a9d81efde41e66c589b16ee401b8ae72a887b016a106a3a0f2ce9afd12560244474ccd11f818143d342169cea769ca073
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/galaxy-station@npm:^2.10.2":
-  version: 2.10.2
-  resolution: "@cosmos-kit/galaxy-station@npm:2.10.2"
-  dependencies:
-    "@cosmos-kit/galaxy-station-extension": "npm:^2.11.2"
-  checksum: 10c0/86721b41a710dae0c8ec22c0466def90ef8b61cd09505e648d145bcd48997413e996cda4330bfce96e2e788cfcd572bbed556ad1d4d8ef693a1e7a6a3cb765d4
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/keplr-extension@npm:^2.12.2":
+"@cosmos-kit/exodus@npm:^2.12.2":
   version: 2.12.2
-  resolution: "@cosmos-kit/keplr-extension@npm:2.12.2"
+  resolution: "@cosmos-kit/exodus@npm:2.12.2"
   dependencies:
-    "@chain-registry/keplr": "npm:^1.68.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
+    "@cosmos-kit/exodus-extension": "npm:^2.12.2"
+  checksum: 10c0/cc734a9a40882b84e35ebd495c1ad470446c9f989f892fd19d679be984cbf486bb9499ac6355f2b7fdeeb9c7e00ae5d05b9be4e390e13e07de2453c4678dfd61
+  languageName: node
+  linkType: hard
+
+"@cosmos-kit/fin-extension@npm:^2.13.3":
+  version: 2.13.3
+  resolution: "@cosmos-kit/fin-extension@npm:2.13.3"
+  dependencies:
+    "@chain-registry/keplr": "npm:^1.69.13"
+    "@cosmos-kit/core": "npm:^2.15.1"
+  peerDependencies:
+    "@cosmjs/amino": ">=0.32.3"
+    "@cosmjs/proto-signing": ">=0.32.3"
+  checksum: 10c0/66137ef31aefac93b297fe08b709cb03fd327e44d248a20797be588bd35bb0413abd2573b9b87327d16bc254d5f70ec65744364dc8899686ae3553a26991d4e2
+  languageName: node
+  linkType: hard
+
+"@cosmos-kit/fin@npm:^2.13.3":
+  version: 2.13.3
+  resolution: "@cosmos-kit/fin@npm:2.13.3"
+  dependencies:
+    "@cosmos-kit/fin-extension": "npm:^2.13.3"
+  checksum: 10c0/8718284b76ad250b48737dd494054c943f7cef3c848b4ee9fa3dacbc837e7d6d013816245765042b6060c2639e1d566de086481f8d7904bb742852338bc4c759
+  languageName: node
+  linkType: hard
+
+"@cosmos-kit/keplr-extension@npm:^2.14.2":
+  version: 2.14.2
+  resolution: "@cosmos-kit/keplr-extension@npm:2.14.2"
+  dependencies:
+    "@chain-registry/keplr": "npm:^1.69.13"
+    "@cosmos-kit/core": "npm:^2.15.1"
     "@keplr-wallet/provider-extension": "npm:^0.12.95"
     "@keplr-wallet/types": "npm:^0.12.95"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/679a71402b31a520dfe4a14ac18b7d3bc2aec75132760f4d3ad67ae91170a52e5c33587fb8208126ffec8ac911fe07413d37edf2d99c4637fec8d836d6338753
+  checksum: 10c0/d7a9b0b430e8538ef538e7ad3f4656811fbde1906bea4148dfbe206124655477285d3742174b6f428725ba4ab51cf3d137e51497364166726f674029e7879676
   languageName: node
   linkType: hard
 
-"@cosmos-kit/keplr-mobile@npm:^2.12.2":
-  version: 2.12.2
-  resolution: "@cosmos-kit/keplr-mobile@npm:2.12.2"
+"@cosmos-kit/keplr-mobile@npm:^2.14.3":
+  version: 2.14.3
+  resolution: "@cosmos-kit/keplr-mobile@npm:2.14.3"
   dependencies:
-    "@chain-registry/keplr": "npm:1.68.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
-    "@cosmos-kit/keplr-extension": "npm:^2.12.2"
-    "@cosmos-kit/walletconnect": "npm:^2.10.1"
+    "@chain-registry/keplr": "npm:^1.69.13"
+    "@cosmos-kit/core": "npm:^2.15.1"
+    "@cosmos-kit/keplr-extension": "npm:^2.14.2"
+    "@cosmos-kit/walletconnect": "npm:^2.12.1"
     "@keplr-wallet/provider-extension": "npm:^0.12.95"
     "@keplr-wallet/wc-client": "npm:^0.12.95"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/9e8ece5399bd206089e796812018e36ba76be39282e6b397316cb8c102512ee3e866d7b297530067f1705aa808095e016ae785295f0f8cc5d3ae2b780c943090
+  checksum: 10c0/d4e774a7a4dbe20690a6aabcd19b349ace795f975314d7d63f4e1c4d00b3eb4b696bb707e736c576d413689988ccdbee0f9eb6c7c4b1d19d419e90cfb6a3c19d
   languageName: node
   linkType: hard
 
-"@cosmos-kit/keplr@npm:^2.12.2":
-  version: 2.12.2
-  resolution: "@cosmos-kit/keplr@npm:2.12.2"
+"@cosmos-kit/keplr@npm:^2.14.3":
+  version: 2.14.3
+  resolution: "@cosmos-kit/keplr@npm:2.14.3"
   dependencies:
-    "@cosmos-kit/keplr-extension": "npm:^2.12.2"
-    "@cosmos-kit/keplr-mobile": "npm:^2.12.2"
-  checksum: 10c0/7bc3c2f6b8c360ab0d8fedc02353341d2ad64351d4f309e2a8374484170975e2cdb1a6866af58a2edb1957cc5e4e28012b43f283d23e4e3e9f0478d2db2770ae
+    "@cosmos-kit/keplr-extension": "npm:^2.14.2"
+    "@cosmos-kit/keplr-mobile": "npm:^2.14.3"
+  checksum: 10c0/f44131c4d32df3be502e271314f7aa8d3693147dda3b258e903bdbc04f1fc7fac2fa1f183d63088612566c9b3187e7fae0c7d8e153e289037aea1d2d8a0e5439
   languageName: node
   linkType: hard
 
-"@cosmos-kit/leap-extension@npm:^2.12.2":
-  version: 2.12.2
-  resolution: "@cosmos-kit/leap-extension@npm:2.12.2"
+"@cosmos-kit/leap-extension@npm:^2.14.3":
+  version: 2.14.3
+  resolution: "@cosmos-kit/leap-extension@npm:2.14.3"
   dependencies:
-    "@chain-registry/keplr": "npm:1.68.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
+    "@chain-registry/keplr": "npm:^1.69.13"
+    "@cosmos-kit/core": "npm:^2.15.1"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/5d7130cefbf5d29e05f7b792ac8f4d31ffd962088a25531d5be7cae5221309755a8a978982baf627d069d9ff315a6de592c527539657ee3dcf6f6957d205d223
+  checksum: 10c0/0d63e1bf76a911aa15781bb9d3faf82af5fdbfe66094aeed40a391f6fc7803c932916dac53d205554ce57206cfc2e1afc9d53c3c0077340051bc43340afa9dba
   languageName: node
   linkType: hard
 
-"@cosmos-kit/leap-metamask-cosmos-snap@npm:^0.12.2":
-  version: 0.12.2
-  resolution: "@cosmos-kit/leap-metamask-cosmos-snap@npm:0.12.2"
+"@cosmos-kit/leap-metamask-cosmos-snap@npm:^0.14.3":
+  version: 0.14.3
+  resolution: "@cosmos-kit/leap-metamask-cosmos-snap@npm:0.14.3"
   dependencies:
-    "@chain-registry/keplr": "npm:1.68.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
+    "@chain-registry/keplr": "npm:^1.69.13"
+    "@cosmos-kit/core": "npm:^2.15.1"
     "@leapwallet/cosmos-snap-provider": "npm:0.1.26"
     "@metamask/providers": "npm:^11.1.1"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
     cosmjs-types: ">=0.9.0"
-  checksum: 10c0/123838d21fb83fce13f4635bf34c6484dd8f5e9f6d24d5ce674afd196e0a67c9f6e3e6068c873160060377c8c231d3089a40e5d93a51c9526eed1bd91d8a0080
+  checksum: 10c0/bbd464264c2ec483b650fea8f90c68b7a53e8b4db87b50776ca8a622852cdba3cf9d00c9eeb5f38edb1f65428d9a1431176e6b3061c0a42574cefca85cb26dd4
   languageName: node
   linkType: hard
 
-"@cosmos-kit/leap-mobile@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/leap-mobile@npm:2.11.2"
+"@cosmos-kit/leap-mobile@npm:^2.13.3":
+  version: 2.13.3
+  resolution: "@cosmos-kit/leap-mobile@npm:2.13.3"
   dependencies:
-    "@chain-registry/keplr": "npm:1.68.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
-    "@cosmos-kit/walletconnect": "npm:^2.10.1"
-  checksum: 10c0/b00131dcdf4155dd6fde16afc3233accf64b31a1dbfbc854b95d7b89642fe95c39d182477cbd102b335b59a59f659072238a29f84e970f3e126694ee22d74596
+    "@chain-registry/keplr": "npm:^1.69.13"
+    "@cosmos-kit/core": "npm:^2.15.1"
+    "@cosmos-kit/walletconnect": "npm:^2.12.1"
+  checksum: 10c0/6b3b6090bfc6bfbcc883c1d6252995dec4f6cdeda16f963bce1a156fcea48164bdb0fec34125fa0ce3bf148accaa7fd0a4fa8ccd525cc71140944f31547ff1d5
   languageName: node
   linkType: hard
 
-"@cosmos-kit/leap@npm:^2.12.2":
+"@cosmos-kit/leap@npm:^2.14.3":
+  version: 2.14.3
+  resolution: "@cosmos-kit/leap@npm:2.14.3"
+  dependencies:
+    "@cosmos-kit/leap-extension": "npm:^2.14.3"
+    "@cosmos-kit/leap-metamask-cosmos-snap": "npm:^0.14.3"
+    "@cosmos-kit/leap-mobile": "npm:^2.13.3"
+  checksum: 10c0/f03f74922a29dd5189dc83b3905d5a06a3e1da7c241b19be52961306d1310f84fb8b98b7350352dc9e4bd2cebb63b97a51acb21ceabe1b2211200196e0d68bd4
+  languageName: node
+  linkType: hard
+
+"@cosmos-kit/ledger@npm:^2.13.3":
+  version: 2.13.3
+  resolution: "@cosmos-kit/ledger@npm:2.13.3"
+  dependencies:
+    "@cosmos-kit/core": "npm:^2.15.1"
+    "@ledgerhq/hw-app-cosmos": "npm:^6.30.4"
+    "@ledgerhq/hw-transport-webhid": "npm:^6.30.0"
+    "@ledgerhq/hw-transport-webusb": "npm:^6.29.4"
+  peerDependencies:
+    "@cosmjs/amino": ">=0.32.4"
+    "@cosmjs/crypto": ">=0.32.4"
+    "@cosmjs/encoding": ">=0.32.4"
+    "@cosmjs/proto-signing": ">=0.32.4"
+  checksum: 10c0/d7016e144c936e6c00952da5d9b015adf4c4a24ea4431f898c5703a3bb41ea3b19890b4fc06ca1e4797eaf2ca146974463e824b90674af1240dadd4f8765802f
+  languageName: node
+  linkType: hard
+
+"@cosmos-kit/okxwallet-extension@npm:^2.13.1":
+  version: 2.13.1
+  resolution: "@cosmos-kit/okxwallet-extension@npm:2.13.1"
+  dependencies:
+    "@cosmos-kit/core": "npm:^2.15.1"
+  peerDependencies:
+    "@cosmjs/amino": ">=0.32.3"
+    "@cosmjs/proto-signing": ">=0.32.3"
+  checksum: 10c0/9c66ea972d20b9fb1488c2e7b8f6665b7235c6315184187fc808e520d64a4b05f760c8ad9aafb8deba5bb00eaed3e9771d8cadcb4b2566ecd32cfd6b05091e73
+  languageName: node
+  linkType: hard
+
+"@cosmos-kit/omni-mobile@npm:^2.12.2":
   version: 2.12.2
-  resolution: "@cosmos-kit/leap@npm:2.12.2"
+  resolution: "@cosmos-kit/omni-mobile@npm:2.12.2"
   dependencies:
-    "@cosmos-kit/leap-extension": "npm:^2.12.2"
-    "@cosmos-kit/leap-metamask-cosmos-snap": "npm:^0.12.2"
-    "@cosmos-kit/leap-mobile": "npm:^2.11.2"
-  checksum: 10c0/cf146378bfd82c7ca84ed4dbd95371ab02b496cd98aa041e5047dfa529f7c9723aae57cc74811f810ebbd737902ea84ea4677d82d9099ab7b2d5c1df19c3a104
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/ledger@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/ledger@npm:2.11.2"
-  dependencies:
-    "@cosmos-kit/core": "npm:^2.13.1"
-    "@ledgerhq/hw-app-cosmos": "npm:^6.28.1"
-    "@ledgerhq/hw-transport-webhid": "npm:^6.27.15"
-    "@ledgerhq/hw-transport-webusb": "npm:^6.27.15"
+    "@cosmos-kit/core": "npm:^2.15.1"
+    "@cosmos-kit/walletconnect": "npm:^2.12.1"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/96bacf4e41569bb274d10871e1974d156bc2a58e2e3bdf7ae7ee1b73630d2267f6a852c114e9ee30cda03ddda9f7e3d74ed2b937e9c575f84f87919804f985ec
+  checksum: 10c0/746445986feff46911499d21046fab601b74af8fe3dbb1393970aa7822eceb409ac69d4b463e663ec0bdfc62eb5d05e53b575279ea10c6044c018c98cfccdbc6
   languageName: node
   linkType: hard
 
-"@cosmos-kit/okxwallet-extension@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/okxwallet-extension@npm:2.11.2"
-  dependencies:
-    "@cosmos-kit/core": "npm:^2.13.1"
-  peerDependencies:
-    "@cosmjs/amino": ">=0.32.3"
-    "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/f2b2bd0067eed702f6a16cf8ef716e1c6a7aa42d8f263b90f4fb8e2346c41a275221a544c4fd42bb50a83d13c254de90d428e1f0b22c3591075e0daf37d069eb
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/omni-mobile@npm:^2.10.2":
-  version: 2.10.2
-  resolution: "@cosmos-kit/omni-mobile@npm:2.10.2"
-  dependencies:
-    "@cosmos-kit/core": "npm:^2.13.1"
-    "@cosmos-kit/walletconnect": "npm:^2.10.1"
-  peerDependencies:
-    "@cosmjs/amino": ">=0.32.3"
-    "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/71a780a4f7a9ffa60be8c35c0515123c4e657a4f4495df23c0343d870838ebac64a65678a15748774b166f60cde5894075534213e354f54d4e12d09cbada3cf3
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/omni@npm:^2.10.2":
-  version: 2.10.2
-  resolution: "@cosmos-kit/omni@npm:2.10.2"
-  dependencies:
-    "@cosmos-kit/omni-mobile": "npm:^2.10.2"
-  checksum: 10c0/d33c64f53f740cf4c50bbdf04a195c8f676d1acfb94aac82b996cd183afdd405602904ac1ff11c41daddcde2a56691f959d528259e7d26d0a57b18ce61d4807e
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/owallet-extension@npm:^2.12.2":
+"@cosmos-kit/omni@npm:^2.12.2":
   version: 2.12.2
-  resolution: "@cosmos-kit/owallet-extension@npm:2.12.2"
+  resolution: "@cosmos-kit/omni@npm:2.12.2"
   dependencies:
-    "@chain-registry/keplr": "npm:1.68.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
+    "@cosmos-kit/omni-mobile": "npm:^2.12.2"
+  checksum: 10c0/478d3ddc7157b8562438fea8bc7c38a17c8771f1e8a6ac01d623be186ae43206a801d9741da3b632e4459a393f065b4211d49f62d8943f43eb9615564e8c8b3e
+  languageName: node
+  linkType: hard
+
+"@cosmos-kit/owallet-extension@npm:^2.14.3":
+  version: 2.14.3
+  resolution: "@cosmos-kit/owallet-extension@npm:2.14.3"
+  dependencies:
+    "@chain-registry/keplr": "npm:^1.69.13"
+    "@cosmos-kit/core": "npm:^2.15.1"
     "@keplr-wallet/types": "npm:^0.12.90"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/c6e10fa9caff33c3a8788ec1be4a12ee2c25d906a4fb24b0b08c387d6ea6c6b6b3d0e2a77e980c0839513a42ef790db897a310327ba0354a0ed79987f98ca285
+  checksum: 10c0/1c18333b267fbeea31c44a976fcb3577dfd48dc23714c474a90bbc21cbd59e7e9f2d78f3f11a6ee3e9c6fc61a8d98022d86781df0d627e197c4798a34a8c2081
   languageName: node
   linkType: hard
 
-"@cosmos-kit/owallet@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/owallet@npm:2.11.2"
+"@cosmos-kit/owallet-mobile@npm:^2.15.2":
+  version: 2.15.2
+  resolution: "@cosmos-kit/owallet-mobile@npm:2.15.2"
   dependencies:
-    "@cosmos-kit/owallet-extension": "npm:^2.12.2"
-  checksum: 10c0/06d2a2b086d932ac18824a926674e6f102c99e4cd8ebfb79e5e0254d594c2ef82b2e44da550144ce56bd685c44a84b6c4cecc421b062b7a1ed07a07ae9f0e52a
+    "@chain-registry/keplr": "npm:1.68.2"
+    "@cosmos-kit/core": "npm:^2.15.1"
+    "@cosmos-kit/walletconnect": "npm:^2.12.1"
+  checksum: 10c0/c1d930d0f55a2dd777690b2672ef003c1edf072df535316ee5b30b48a414d795cef1d09cf96b099e6e60afc357cdba1cc4776a6f2da09bdd13b37adde0682002
+  languageName: node
+  linkType: hard
+
+"@cosmos-kit/owallet@npm:^2.14.2":
+  version: 2.14.2
+  resolution: "@cosmos-kit/owallet@npm:2.14.2"
+  dependencies:
+    "@cosmos-kit/owallet-extension": "npm:^2.14.3"
+    "@cosmos-kit/owallet-mobile": "npm:^2.15.2"
+  checksum: 10c0/70aabde56b9941c71269dc2d8cab5a68e733c9c98b1c15ca80edbafbf4a7b9ae75619f21d22c6873b1447ac1e4d62ef32e401099c83a0c3d731a6b378fc94b56
   languageName: node
   linkType: hard
 
@@ -2646,162 +2700,94 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmos-kit/shell-extension@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/shell-extension@npm:2.11.2"
+"@cosmos-kit/shell-extension@npm:^2.13.3":
+  version: 2.13.3
+  resolution: "@cosmos-kit/shell-extension@npm:2.13.3"
   dependencies:
-    "@chain-registry/keplr": "npm:1.68.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
+    "@chain-registry/keplr": "npm:^1.69.13"
+    "@cosmos-kit/core": "npm:^2.15.1"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/c708c603aab2c7c289f8decfc8cb7b833595734e147f8905f8cd30a4bf288391f0c3366f2a8e4855041b12495ed70a40cb98470edd446a495277d00b4e91518c
+  checksum: 10c0/0e40b2910caffa7386a9f1b707f050e6315d2bc779f5d8a9cb6fa54936ee48bf0732ad1a543a89ce21e69872707b42c253ef676797d7bccb112af3b317e49c80
   languageName: node
   linkType: hard
 
-"@cosmos-kit/shell@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/shell@npm:2.11.2"
+"@cosmos-kit/shell@npm:^2.13.3":
+  version: 2.13.3
+  resolution: "@cosmos-kit/shell@npm:2.13.3"
   dependencies:
-    "@cosmos-kit/shell-extension": "npm:^2.11.2"
-  checksum: 10c0/cc531070a980b4fa57a34ee96b54d070fe9782e4477ff9da997ae37e6f30d3ea5921ea523768bd70f72e0eddf46f67ba592e4b7fe75b99679bc7da562797ccf0
+    "@cosmos-kit/shell-extension": "npm:^2.13.3"
+  checksum: 10c0/01f3a73814c0c227118a6863468ce92f6e98ecc7fd2c3df3184dcc74c080cb5f0971de9c1ca84d879f6ae66dd6b97fdc91b3ced417cab03e18e32eb878efc946
   languageName: node
   linkType: hard
 
-"@cosmos-kit/station-extension@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/station-extension@npm:2.11.2"
+"@cosmos-kit/tailwind-extension@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "@cosmos-kit/tailwind-extension@npm:1.7.2"
   dependencies:
-    "@cosmos-kit/core": "npm:^2.13.1"
-    "@terra-money/feather.js": "npm:^1.0.8"
-    "@terra-money/station-connector": "npm:^1.1.0"
-    "@terra-money/wallet-types": "npm:^3.11.2"
-  peerDependencies:
-    "@chain-registry/types": ">= 0.17"
-    "@cosmjs/amino": ">=0.32.3"
-    "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/0532961a303ab7cad2319f27c71c80f9662ec9f7a5d957f27dc49c8753417dbc94c4ec175010b9b616af1512e42dc09144a12c5c143a5ab64bb2015d0fc6768e
+    "@cosmos-kit/core": "npm:^2.15.1"
+  checksum: 10c0/d674c57aca16e382c041484fd31748848c14455f6c72ec5d87638ef643d43093d3aa4325ba3c04787d631b1e17025babbd9338556b517c2d94ccac90103441cb
   languageName: node
   linkType: hard
 
-"@cosmos-kit/station@npm:^2.10.2":
-  version: 2.10.2
-  resolution: "@cosmos-kit/station@npm:2.10.2"
+"@cosmos-kit/tailwind@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "@cosmos-kit/tailwind@npm:1.7.2"
   dependencies:
-    "@cosmos-kit/station-extension": "npm:^2.11.2"
-  checksum: 10c0/1d0e1a05e9fd2528d1c105fba340244adff25460b536d75fcc2454f56f317efd6edced3eddee9cc8b9d897338114f9469af272fd1a5f7f1c317273acfc5f29b4
+    "@cosmos-kit/tailwind-extension": "npm:^1.7.2"
+  checksum: 10c0/8ae14b9502307a52ad4e1ca3fd74f6ec0d95d7e3dd57072e894b4d28a77a848835281d36c19f6ac63f7d64e53b5d8715733ce6ecfbc2da0af76e2b3a348afd06
   languageName: node
   linkType: hard
 
-"@cosmos-kit/tailwind-extension@npm:^1.5.2":
-  version: 1.5.2
-  resolution: "@cosmos-kit/tailwind-extension@npm:1.5.2"
+"@cosmos-kit/trust-extension@npm:^2.12.2":
+  version: 2.12.2
+  resolution: "@cosmos-kit/trust-extension@npm:2.12.2"
   dependencies:
-    "@cosmos-kit/core": "npm:^2.13.1"
-  checksum: 10c0/a8facdddc4df41814ae5048423b3c9da8c223503f16fb6728038238790fd143a2ebda727c813f9ae2c1190c0d0da07e942a8c0181ea2e1268f9580435550d2ed
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/tailwind@npm:^1.5.2":
-  version: 1.5.2
-  resolution: "@cosmos-kit/tailwind@npm:1.5.2"
-  dependencies:
-    "@cosmos-kit/tailwind-extension": "npm:^1.5.2"
-  checksum: 10c0/79d9ce43765e90c990f52d72049d4705322d3fc9175214f80aec7d24cbce24460cf37aaab9baf424aa965ff2b9398e3c84c32f8ac2bb5c4a35370ebddefc4733
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/trust-extension@npm:^2.10.2":
-  version: 2.10.2
-  resolution: "@cosmos-kit/trust-extension@npm:2.10.2"
-  dependencies:
-    "@cosmos-kit/core": "npm:^2.13.1"
+    "@cosmos-kit/core": "npm:^2.15.1"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/4a56176642f984aa07a3b46f4dfed59113e4012350c45b854c4ea96cedd2dbf8cbf07e7c9a943ffaf85d624c0f8612d3eb6dd2518926ce82289a48a208859f13
+  checksum: 10c0/7f8f23a8f046c24077e4e0f5ac1423ffefa63550d0312d6c64e46f692f11331a3244f8628cc1d125fc1adabe9721a86c9a537532adef082dfd913062bbdf47d0
   languageName: node
   linkType: hard
 
-"@cosmos-kit/trust-mobile@npm:^2.10.2":
-  version: 2.10.2
-  resolution: "@cosmos-kit/trust-mobile@npm:2.10.2"
+"@cosmos-kit/trust-mobile@npm:^2.12.2":
+  version: 2.12.2
+  resolution: "@cosmos-kit/trust-mobile@npm:2.12.2"
   dependencies:
-    "@cosmos-kit/core": "npm:^2.13.1"
-    "@cosmos-kit/walletconnect": "npm:^2.10.1"
+    "@cosmos-kit/core": "npm:^2.15.1"
+    "@cosmos-kit/walletconnect": "npm:^2.12.1"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/6ed367a52d75355add3bddcbefc47e589110da9e1d42f7b65fdd7e02398786d083403f685539ea03a0b65f9a9813e1703d2c53a67aa834c091170e488b77205c
+  checksum: 10c0/973f97d821bf48af96198cb347de37ccc9ca661e30e0cdd731d294b5c4195d2de036fb56f11429cbae4bff5f86a4dfc1979b37998f29bf22bc398fd0cd759594
   languageName: node
   linkType: hard
 
-"@cosmos-kit/trust@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/trust@npm:2.11.2"
+"@cosmos-kit/trust@npm:^2.13.2":
+  version: 2.13.2
+  resolution: "@cosmos-kit/trust@npm:2.13.2"
   dependencies:
-    "@cosmos-kit/trust-extension": "npm:^2.10.2"
-    "@cosmos-kit/trust-mobile": "npm:^2.10.2"
-  checksum: 10c0/68824bdab267de17b5ed0689a6b2a4881b06d5ec292bc1d12d9890552039229f6768eaf0e0ac8017633f67e9140a56da62df514f13f9aa6de09e7a55cc350132
+    "@cosmos-kit/trust-extension": "npm:^2.12.2"
+    "@cosmos-kit/trust-mobile": "npm:^2.12.2"
+  checksum: 10c0/abb0ecd5ca748f87195ea66cc8451511533e417f286ac5639d0656729ebf86324326e2f8ad3c8a0df946aaf69a8378b7bc6c711f10a501dc7a9962276e9bacb3
   languageName: node
   linkType: hard
 
-"@cosmos-kit/vectis-extension@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/vectis-extension@npm:2.11.2"
-  dependencies:
-    "@chain-registry/keplr": "npm:1.68.2"
-    "@cosmos-kit/core": "npm:^2.13.1"
-  peerDependencies:
-    "@cosmjs/amino": ">=0.32.3"
-    "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/d150dd1f8845073b98d4ebf1d59f8459881cfc3e7b954fe0cd1932852bc7cb1986da6c44cbea7d06ce57c971fd8a1d5b7daa7c27fb0d31abfb4b1fdc786bd2b4
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/vectis@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/vectis@npm:2.11.2"
-  dependencies:
-    "@cosmos-kit/vectis-extension": "npm:^2.11.2"
-  checksum: 10c0/e9baa032280d35fc6da13a771bb7e4180decede89f052d9297e702d9ea3aaed7ce92d98865e2bb3b60f8a86ae7770add714db8072d64c89fd8d00449887ddee7
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/walletconnect@npm:^2.10.1":
-  version: 2.10.1
-  resolution: "@cosmos-kit/walletconnect@npm:2.10.1"
+"@cosmos-kit/walletconnect@npm:^2.12.1":
+  version: 2.12.1
+  resolution: "@cosmos-kit/walletconnect@npm:2.12.1"
   dependencies:
     "@cosmjs/proto-signing": "npm:^0.32.3"
-    "@cosmos-kit/core": "npm:^2.13.1"
+    "@cosmos-kit/core": "npm:^2.15.1"
     "@walletconnect/sign-client": "npm:^2.9.0"
     "@walletconnect/utils": "npm:^2.9.0"
     events: "npm:3.3.0"
   peerDependencies:
     "@cosmjs/amino": ">=0.32.3"
     "@walletconnect/types": 2.11.0
-  checksum: 10c0/5940d33dfebb75f029b57cfa1de9206d2fc3c36e406cef29786ac5c0cd749cd0f5c06e5953d096bc522f45d8c1903cb1aa4429ee07425f261cc3167dcb6b35b6
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/xdefi-extension@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "@cosmos-kit/xdefi-extension@npm:2.11.2"
-  dependencies:
-    "@cosmos-kit/core": "npm:^2.13.1"
-  peerDependencies:
-    "@cosmjs/amino": ">=0.32.3"
-    "@cosmjs/proto-signing": ">=0.32.3"
-  checksum: 10c0/73afc1fb1ed406c5fa44081baf2c0b3d0fd90e6d162427e66040f8319a10ef72c756bd180861400f0f1b51cdd8d54c4a4fdb56fb71eda1aef2003d3131a7404a
-  languageName: node
-  linkType: hard
-
-"@cosmos-kit/xdefi@npm:^2.10.2":
-  version: 2.10.2
-  resolution: "@cosmos-kit/xdefi@npm:2.10.2"
-  dependencies:
-    "@cosmos-kit/xdefi-extension": "npm:^2.11.2"
-  checksum: 10c0/a7dcb2a6234d4828f60fa835247627a6183fe000f4e2106f8c6a1e2bff5c2c842a887a5ddae188e2d500b807e1d4580fddfb318499683914f0abf6ffa2f72faa
+  checksum: 10c0/f3fedcdeaee8737597c176f7a370794853f9abcc3fbba3e601cf92b416b2464419141c1867adbe83db21e202a18129cf6599fc6c4b3bc6ef4e319ec2a88d67cc
   languageName: node
   linkType: hard
 
@@ -2841,6 +2827,18 @@ __metadata:
     "@cosmjs/amino": "*"
     "@cosmjs/proto-signing": "*"
   checksum: 10c0/e65a64a8ce67063585c2f21c07a7443358cfcbd2153c432b2e882a0549e37edb8d5a375ef49d279d2ec7cb46dfce6d728ccc872cdf89a444602319d11e44ccc8
+  languageName: node
+  linkType: hard
+
+"@dao-dao/cosmiframe@npm:^1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@dao-dao/cosmiframe@npm:1.0.0-rc.1"
+  dependencies:
+    uuid: "npm:^9.0.1"
+  peerDependencies:
+    "@cosmjs/amino": "*"
+    "@cosmjs/proto-signing": "*"
+  checksum: 10c0/145af9b412d24e56827085328689b99c40e1116d50b76f0219ddacfe74b8c4249f74653bbbe58733636dca109119ba342d2976c2dcee3198e3b01b4257b3b9bc
   languageName: node
   linkType: hard
 
@@ -4723,41 +4721,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hexxagon/feather.js@npm:@terra-money/feather.js@1.0.3":
-  version: 1.0.3
-  resolution: "@terra-money/feather.js@npm:1.0.3"
-  dependencies:
-    "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7"
-    "@terra-money/terra.proto": "npm:3.0.5"
-    axios: "npm:^0.27.2"
-    bech32: "npm:^2.0.0"
-    bip32: "npm:^2.0.6"
-    bip39: "npm:^3.0.3"
-    bufferutil: "npm:^4.0.3"
-    decimal.js: "npm:^10.2.1"
-    jscrypto: "npm:^1.0.1"
-    readable-stream: "npm:^3.6.0"
-    secp256k1: "npm:^4.0.2"
-    tmp: "npm:^0.2.1"
-    utf-8-validate: "npm:^5.0.5"
-    ws: "npm:^7.5.9"
-  checksum: 10c0/ef64997bd65e08db40f0c717eac403ab76c971870d593fe0a426567b8103893e6cb8f2c8cc6fe268793b4a1f408409d5fdf477f84e2cd9a098151a0b379cf4a2
-  languageName: node
-  linkType: hard
-
-"@hexxagon/station-connector@npm:^1.0.17":
-  version: 1.0.19
-  resolution: "@hexxagon/station-connector@npm:1.0.19"
-  dependencies:
-    bech32: "npm:^2.0.0"
-  peerDependencies:
-    "@cosmjs/amino": ^0.31.0
-    "@hexxagon/feather.js": ^2.1.0-beta.5
-    axios: ^0.27.2
-  checksum: 10c0/32d1eb7d20b941c199ebbf68022b9caa94ecdbee6983d7b66d64868362c03a684befb6c7432990afb28a4540ea304e7d5ed2d7823f204165345018ff71644417
-  languageName: node
-  linkType: hard
-
 "@humanwhocodes/config-array@npm:^0.13.0":
   version: 0.13.0
   resolution: "@humanwhocodes/config-array@npm:0.13.0"
@@ -4787,17 +4750,6 @@ __metadata:
   version: 2.2.5
   resolution: "@iarna/toml@npm:2.2.5"
   checksum: 10c0/d095381ad4554aca233b7cf5a91f243ef619e5e15efd3157bc640feac320545450d14b394aebbf6f02a2047437ced778ae598d5879a995441ab7b6c0b2c2f201
-  languageName: node
-  linkType: hard
-
-"@improbable-eng/grpc-web@npm:^0.14.1":
-  version: 0.14.1
-  resolution: "@improbable-eng/grpc-web@npm:0.14.1"
-  dependencies:
-    browser-headers: "npm:^0.4.1"
-  peerDependencies:
-    google-protobuf: ^3.14.0
-  checksum: 10c0/972f20d97970b3c7239ef8f26866e417e3079faec5a66e86755cc49b1dc3c56ed50a8f04dbb9d23d2f12ffb5719e39500d5e513d0087d576bc0844d2034491c1
   languageName: node
   linkType: hard
 
@@ -5219,69 +5171,69 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/devices@npm:^8.2.2":
-  version: 8.2.2
-  resolution: "@ledgerhq/devices@npm:8.2.2"
+"@ledgerhq/devices@npm:8.4.4, @ledgerhq/devices@npm:^8.4.4":
+  version: 8.4.4
+  resolution: "@ledgerhq/devices@npm:8.4.4"
   dependencies:
-    "@ledgerhq/errors": "npm:^6.16.3"
+    "@ledgerhq/errors": "npm:^6.19.1"
     "@ledgerhq/logs": "npm:^6.12.0"
     rxjs: "npm:^7.8.1"
     semver: "npm:^7.3.5"
-  checksum: 10c0/c9bd63858ac4ce37a8e8fa3523ec1ed343b381d9711404d4334ef89d8cc8898af85e951b48ad962dce9a9c98344f0942393b69e52627cc34ec6e1b0dc93a5bbd
+  checksum: 10c0/ea4c3dada124c5c0aad59837e1c399bf2f41f8b4da5c996aaf73bbf8719082598808947c505dc728266ff83fc5fea71170d3f0d18a9b5d59e6e2737ae8a38f39
   languageName: node
   linkType: hard
 
-"@ledgerhq/errors@npm:^6.16.3":
-  version: 6.16.3
-  resolution: "@ledgerhq/errors@npm:6.16.3"
-  checksum: 10c0/12e8e39317aac45694ae0f01f20b870a933611cd31187fc6ff63f268154b58f99d34b02f5dc033cbe3aebbe6fbfcd6f19aea842b7de22b5d8e051aef2fb94f94
+"@ledgerhq/errors@npm:^6.19.1":
+  version: 6.19.1
+  resolution: "@ledgerhq/errors@npm:6.19.1"
+  checksum: 10c0/5cfbd5ff5e4316afc88c456a74d3dc0e0032dafd88f656e80a5cb5b297a75ba6701c53ce38ef3f38a84a8591c499b0b9248cdf352ff34c97a550440cdaddd8d2
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-app-cosmos@npm:^6.28.1":
-  version: 6.29.5
-  resolution: "@ledgerhq/hw-app-cosmos@npm:6.29.5"
+"@ledgerhq/hw-app-cosmos@npm:^6.30.4":
+  version: 6.30.4
+  resolution: "@ledgerhq/hw-app-cosmos@npm:6.30.4"
   dependencies:
-    "@ledgerhq/errors": "npm:^6.16.3"
-    "@ledgerhq/hw-transport": "npm:^6.30.5"
+    "@ledgerhq/errors": "npm:^6.19.1"
+    "@ledgerhq/hw-transport": "npm:^6.31.4"
     bip32-path: "npm:^0.4.2"
-  checksum: 10c0/0b1988defdf762abe3cd8d160f1e5234056765d0c4d13459300cef1c524a5b925dd85cb8c0357288537c040b72f48cb7d20a797770fdd1d24631a65b6419e3e9
+  checksum: 10c0/d446c7d2ab8a2a803ba728ff68401c61ff49f1070b949fea14d7223e8e795928bcbb5c295a4dc8f6fccb74fe25b8e30991125dae864edcd0d8a7ea4e0b1aa92d
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-transport-webhid@npm:^6.27.15":
-  version: 6.28.5
-  resolution: "@ledgerhq/hw-transport-webhid@npm:6.28.5"
+"@ledgerhq/hw-transport-webhid@npm:^6.30.0":
+  version: 6.30.0
+  resolution: "@ledgerhq/hw-transport-webhid@npm:6.30.0"
   dependencies:
-    "@ledgerhq/devices": "npm:^8.2.2"
-    "@ledgerhq/errors": "npm:^6.16.3"
-    "@ledgerhq/hw-transport": "npm:^6.30.5"
+    "@ledgerhq/devices": "npm:8.4.4"
+    "@ledgerhq/errors": "npm:^6.19.1"
+    "@ledgerhq/hw-transport": "npm:^6.31.4"
     "@ledgerhq/logs": "npm:^6.12.0"
-  checksum: 10c0/e9233f83b9f5ee4ab480ffd894c44251c85d6a11c2591665ee5b91ce0997316a822bbd52ca9129736f074df5d809df576c528fd009a309652c1cc1bb41fe4862
+  checksum: 10c0/1cb6ddb50127d6cb73d80259e10da687a2b7aa87ebbac8cc3e770ac5b95a3ef0001bdaf77109da0eb62509cb8668a9642858b59cb0ff355c1adb0fe2114c532c
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-transport-webusb@npm:^6.27.15":
-  version: 6.28.5
-  resolution: "@ledgerhq/hw-transport-webusb@npm:6.28.5"
+"@ledgerhq/hw-transport-webusb@npm:^6.29.4":
+  version: 6.29.4
+  resolution: "@ledgerhq/hw-transport-webusb@npm:6.29.4"
   dependencies:
-    "@ledgerhq/devices": "npm:^8.2.2"
-    "@ledgerhq/errors": "npm:^6.16.3"
-    "@ledgerhq/hw-transport": "npm:^6.30.5"
+    "@ledgerhq/devices": "npm:^8.4.4"
+    "@ledgerhq/errors": "npm:^6.19.1"
+    "@ledgerhq/hw-transport": "npm:^6.31.4"
     "@ledgerhq/logs": "npm:^6.12.0"
-  checksum: 10c0/25ae085cf6f74202f7c4d089aca39058790d32fa287de9fb3e7ae982fd9e80c34988ad3b82249b856839db81165e0c94f02a0a3954866b83f2cf13c393e3a2ba
+  checksum: 10c0/cddd324c12de64e755422c6dc0d509bc344f2f048c2b743bc5737db9c097ffb6c201fc577d971543e196ccb34a72507450ed3262a2b6d39c753424d299fafc2f
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-transport@npm:^6.30.5":
-  version: 6.30.5
-  resolution: "@ledgerhq/hw-transport@npm:6.30.5"
+"@ledgerhq/hw-transport@npm:^6.31.4":
+  version: 6.31.4
+  resolution: "@ledgerhq/hw-transport@npm:6.31.4"
   dependencies:
-    "@ledgerhq/devices": "npm:^8.2.2"
-    "@ledgerhq/errors": "npm:^6.16.3"
+    "@ledgerhq/devices": "npm:^8.4.4"
+    "@ledgerhq/errors": "npm:^6.19.1"
     "@ledgerhq/logs": "npm:^6.12.0"
     events: "npm:^3.3.0"
-  checksum: 10c0/ef80bb7d5839e3f2dc278fc4aaa2a2e74766cce80cfc0c42958601ce231ce576e2cd318ead971aa09263e43592160a5256a945ccb31dc542a341ad26f871102f
+  checksum: 10c0/033acb802d991788efcda9223356528d0987a268e94c34cbafde499541722363e7cfa6e2734365ef3282c0a80a69f4964a6d728690ff7494662a650516530b02
   languageName: node
   linkType: hard
 
@@ -7823,92 +7775,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terra-money/feather.js@npm:^1.0.8":
-  version: 1.2.1
-  resolution: "@terra-money/feather.js@npm:1.2.1"
-  dependencies:
-    "@ethersproject/bytes": "npm:^5.7.0"
-    "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7"
-    "@terra-money/terra.proto": "npm:^4.0.3"
-    assert: "npm:^2.0.0"
-    axios: "npm:^0.27.2"
-    bech32: "npm:^2.0.0"
-    bip32: "npm:^2.0.6"
-    bip39: "npm:^3.0.3"
-    bufferutil: "npm:^4.0.3"
-    crypto-browserify: "npm:^3.12.0"
-    decimal.js: "npm:^10.2.1"
-    ethers: "npm:^5.7.2"
-    jscrypto: "npm:^1.0.1"
-    keccak256: "npm:^1.0.6"
-    long: "npm:^5.2.3"
-    readable-stream: "npm:^3.6.0"
-    secp256k1: "npm:^4.0.2"
-    tmp: "npm:^0.2.1"
-    utf-8-validate: "npm:^5.0.5"
-    ws: "npm:^7.5.9"
-  checksum: 10c0/bf1c952bf6e6531f663727c5793bfc4a9fb1a6025eed0b8f68f994bedced184a11d961a4ae42620690108171428933fc48e68ea078b53c2375b938b791eb4ff0
-  languageName: node
-  linkType: hard
-
-"@terra-money/legacy.proto@npm:@terra-money/terra.proto@^0.1.7":
-  version: 0.1.7
-  resolution: "@terra-money/terra.proto@npm:0.1.7"
-  dependencies:
-    google-protobuf: "npm:^3.17.3"
-    long: "npm:^4.0.0"
-    protobufjs: "npm:~6.11.2"
-  checksum: 10c0/3ae54002eac9b8fa7dcc90e167ca50134fd5d36549a336e1aa02c9deb6133441d755e6681a6a272e51c70e27610e1566ee5ccf1e2174f239f81b631cb7a8eead
-  languageName: node
-  linkType: hard
-
-"@terra-money/station-connector@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@terra-money/station-connector@npm:1.1.0"
-  dependencies:
-    bech32: "npm:^2.0.0"
-  peerDependencies:
-    "@cosmjs/amino": ^0.31.0
-    "@terra-money/feather.js": ^3.0.0-beta.1
-    axios: ^0.27.2
-  checksum: 10c0/9749876044357bc0f28ceeb15a1535b8201e6fa3eb09e95c0374ecba04b87d85388a4d5c491b2a89cc3b02ad24c8fa055e69240ae937c16f5bee196416263898
-  languageName: node
-  linkType: hard
-
-"@terra-money/terra.proto@npm:3.0.5":
-  version: 3.0.5
-  resolution: "@terra-money/terra.proto@npm:3.0.5"
-  dependencies:
-    "@improbable-eng/grpc-web": "npm:^0.14.1"
-    google-protobuf: "npm:^3.17.3"
-    long: "npm:^4.0.0"
-    protobufjs: "npm:~6.11.2"
-  checksum: 10c0/f057cbf49dd8dc9effce875f2e60b7c0f17b375b160f08887a3007998584be834141f221dad642c68aac5324583f6e95d06fecc1fc8ee18374960bdd58808538
-  languageName: node
-  linkType: hard
-
-"@terra-money/terra.proto@npm:^4.0.3":
-  version: 4.0.10
-  resolution: "@terra-money/terra.proto@npm:4.0.10"
-  dependencies:
-    "@improbable-eng/grpc-web": "npm:^0.14.1"
-    browser-headers: "npm:^0.4.1"
-    google-protobuf: "npm:^3.17.3"
-    long: "npm:^4.0.0"
-    protobufjs: "npm:~6.11.2"
-  checksum: 10c0/80e701fe8ff5420c896acda16682cc8ad3aa4a317bbfcae89c5576a2ad800f349b0cb1d9bba82c1770829e083bbfbbf82ba2d6124ea06c8b64a17d386126c71e
-  languageName: node
-  linkType: hard
-
-"@terra-money/wallet-types@npm:^3.11.2":
-  version: 3.11.2
-  resolution: "@terra-money/wallet-types@npm:3.11.2"
-  peerDependencies:
-    "@terra-money/terra.js": ^3.1.6
-  checksum: 10c0/3fe1d475bb02655b4d4817dfbddf52f6ecbb87c8731a0c2077f4a5c36c88c730e9d167e802294b04fd6f25f841f68ab12f159f69164375c00dac2a9b6e6f32f5
-  languageName: node
-  linkType: hard
-
 "@tsconfig/node10@npm:^1.0.7":
   version: 1.0.11
   resolution: "@tsconfig/node10@npm:1.0.11"
@@ -9527,30 +9393,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asn1.js@npm:^4.10.1":
-  version: 4.10.1
-  resolution: "asn1.js@npm:4.10.1"
-  dependencies:
-    bn.js: "npm:^4.0.0"
-    inherits: "npm:^2.0.1"
-    minimalistic-assert: "npm:^1.0.0"
-  checksum: 10c0/afa7f3ab9e31566c80175a75b182e5dba50589dcc738aa485be42bdd787e2a07246a4b034d481861123cbe646a7656f318f4f1cad2e9e5e808a210d5d6feaa88
-  languageName: node
-  linkType: hard
-
-"assert@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "assert@npm:2.1.0"
-  dependencies:
-    call-bind: "npm:^1.0.2"
-    is-nan: "npm:^1.3.2"
-    object-is: "npm:^1.1.5"
-    object.assign: "npm:^4.1.4"
-    util: "npm:^0.12.5"
-  checksum: 10c0/7271a5da883c256a1fa690677bf1dd9d6aa882139f2bed1cd15da4f9e7459683e1da8e32a203d6cc6767e5e0f730c77a9532a87b896b4b0af0dd535f668775f0
-  languageName: node
-  linkType: hard
-
 "ast-types-flow@npm:^0.0.8":
   version: 0.0.8
   resolution: "ast-types-flow@npm:0.0.8"
@@ -9759,7 +9601,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bech32@npm:2.0.0, bech32@npm:^2.0.0":
+"bech32@npm:2.0.0":
   version: 2.0.0
   resolution: "bech32@npm:2.0.0"
   checksum: 10c0/45e7cc62758c9b26c05161b4483f40ea534437cf68ef785abadc5b62a2611319b878fef4f86ddc14854f183b645917a19addebc9573ab890e19194bc8f521942
@@ -9912,14 +9754,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.8, bn.js@npm:^4.11.9":
+"bn.js@npm:^4.11.8, bn.js@npm:^4.11.9":
   version: 4.12.0
   resolution: "bn.js@npm:4.12.0"
   checksum: 10c0/9736aaa317421b6b3ed038ff3d4491935a01419ac2d83ddcfebc5717385295fcfcf0c57311d90fe49926d0abbd7a9dbefdd8861e6129939177f7e67ebc645b21
   languageName: node
   linkType: hard
 
-"bn.js@npm:^5.0.0, bn.js@npm:^5.1.1, bn.js@npm:^5.2.0, bn.js@npm:^5.2.1":
+"bn.js@npm:^5.1.1, bn.js@npm:^5.2.0, bn.js@npm:^5.2.1":
   version: 5.2.1
   resolution: "bn.js@npm:5.2.1"
   checksum: 10c0/bed3d8bd34ec89dbcf9f20f88bd7d4a49c160fda3b561c7bb227501f974d3e435a48fb9b61bc3de304acab9215a3bda0803f7017ffb4d0016a0c3a740a283caa
@@ -9972,82 +9814,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brorand@npm:^1.0.1, brorand@npm:^1.1.0":
+"brorand@npm:^1.1.0":
   version: 1.1.0
   resolution: "brorand@npm:1.1.0"
   checksum: 10c0/6f366d7c4990f82c366e3878492ba9a372a73163c09871e80d82fb4ae0d23f9f8924cb8a662330308206e6b3b76ba1d528b4601c9ef73c2166b440b2ea3b7571
-  languageName: node
-  linkType: hard
-
-"browser-headers@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "browser-headers@npm:0.4.1"
-  checksum: 10c0/3b08864bb955b295ab3dd6ab775c7798096c2e85486571803b4070ec484de83ccceebe531a8b00d5daf4463fada5e7ca18cd1a71cc1ee0dfdbab705332318cef
-  languageName: node
-  linkType: hard
-
-"browserify-aes@npm:^1.0.4, browserify-aes@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "browserify-aes@npm:1.2.0"
-  dependencies:
-    buffer-xor: "npm:^1.0.3"
-    cipher-base: "npm:^1.0.0"
-    create-hash: "npm:^1.1.0"
-    evp_bytestokey: "npm:^1.0.3"
-    inherits: "npm:^2.0.1"
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/967f2ae60d610b7b252a4cbb55a7a3331c78293c94b4dd9c264d384ca93354c089b3af9c0dd023534efdc74ffbc82510f7ad4399cf82bc37bc07052eea485f18
-  languageName: node
-  linkType: hard
-
-"browserify-cipher@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "browserify-cipher@npm:1.0.1"
-  dependencies:
-    browserify-aes: "npm:^1.0.4"
-    browserify-des: "npm:^1.0.0"
-    evp_bytestokey: "npm:^1.0.0"
-  checksum: 10c0/aa256dcb42bc53a67168bbc94ab85d243b0a3b56109dee3b51230b7d010d9b78985ffc1fb36e145c6e4db151f888076c1cfc207baf1525d3e375cbe8187fe27d
-  languageName: node
-  linkType: hard
-
-"browserify-des@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "browserify-des@npm:1.0.2"
-  dependencies:
-    cipher-base: "npm:^1.0.1"
-    des.js: "npm:^1.0.0"
-    inherits: "npm:^2.0.1"
-    safe-buffer: "npm:^5.1.2"
-  checksum: 10c0/943eb5d4045eff80a6cde5be4e5fbb1f2d5002126b5a4789c3c1aae3cdddb1eb92b00fb92277f512288e5c6af330730b1dbabcf7ce0923e749e151fcee5a074d
-  languageName: node
-  linkType: hard
-
-"browserify-rsa@npm:^4.0.0, browserify-rsa@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "browserify-rsa@npm:4.1.0"
-  dependencies:
-    bn.js: "npm:^5.0.0"
-    randombytes: "npm:^2.0.1"
-  checksum: 10c0/fb2b5a8279d8a567a28d8ee03fb62e448428a906bab5c3dc9e9c3253ace551b5ea271db15e566ac78f1b1d71b243559031446604168b9235c351a32cae99d02a
-  languageName: node
-  linkType: hard
-
-"browserify-sign@npm:^4.0.0":
-  version: 4.2.3
-  resolution: "browserify-sign@npm:4.2.3"
-  dependencies:
-    bn.js: "npm:^5.2.1"
-    browserify-rsa: "npm:^4.1.0"
-    create-hash: "npm:^1.2.0"
-    create-hmac: "npm:^1.1.7"
-    elliptic: "npm:^6.5.5"
-    hash-base: "npm:~3.0"
-    inherits: "npm:^2.0.4"
-    parse-asn1: "npm:^5.1.7"
-    readable-stream: "npm:^2.3.8"
-    safe-buffer: "npm:^5.2.1"
-  checksum: 10c0/30c0eba3f5970a20866a4d3fbba2c5bd1928cd24f47faf995f913f1499214c6f3be14bb4d6ec1ab5c6cafb1eca9cb76ba1c2e1c04ed018370634d4e659c77216
   languageName: node
   linkType: hard
 
@@ -10085,13 +9855,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-xor@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "buffer-xor@npm:1.0.3"
-  checksum: 10c0/fd269d0e0bf71ecac3146187cfc79edc9dbb054e2ee69b4d97dfb857c6d997c33de391696d04bdd669272751fa48e7872a22f3a6c7b07d6c0bc31dbe02a4075c
-  languageName: node
-  linkType: hard
-
 "buffer@npm:6.0.3, buffer@npm:^6.0.3, buffer@npm:~6.0.3":
   version: 6.0.3
   resolution: "buffer@npm:6.0.3"
@@ -10112,7 +9875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bufferutil@npm:^4.0.1, bufferutil@npm:^4.0.3":
+"bufferutil@npm:^4.0.1":
   version: 4.0.8
   resolution: "bufferutil@npm:4.0.8"
   dependencies:
@@ -10149,7 +9912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind@npm:^1.0.0, call-bind@npm:^1.0.2, call-bind@npm:^1.0.5, call-bind@npm:^1.0.6, call-bind@npm:^1.0.7":
+"call-bind@npm:^1.0.2, call-bind@npm:^1.0.5, call-bind@npm:^1.0.6, call-bind@npm:^1.0.7":
   version: 1.0.7
   resolution: "call-bind@npm:1.0.7"
   dependencies:
@@ -10312,7 +10075,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cipher-base@npm:^1.0.0, cipher-base@npm:^1.0.1, cipher-base@npm:^1.0.3":
+"cipher-base@npm:^1.0.1, cipher-base@npm:^1.0.3":
   version: 1.0.4
   resolution: "cipher-base@npm:1.0.4"
   dependencies:
@@ -10690,45 +10453,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmos-kit@npm:^2.19.0":
-  version: 2.19.0
-  resolution: "cosmos-kit@npm:2.19.0"
+"cosmos-kit@npm:^2.8.5":
+  version: 2.23.5
+  resolution: "cosmos-kit@npm:2.23.5"
   dependencies:
-    "@cosmos-kit/cdcwallet": "npm:^2.13.2"
-    "@cosmos-kit/coin98": "npm:^2.11.2"
-    "@cosmos-kit/compass": "npm:^2.11.2"
-    "@cosmos-kit/cosmostation": "npm:^2.12.0"
-    "@cosmos-kit/exodus": "npm:^2.10.2"
-    "@cosmos-kit/fin": "npm:^2.11.2"
-    "@cosmos-kit/frontier": "npm:^2.10.2"
-    "@cosmos-kit/galaxy-station": "npm:^2.10.2"
-    "@cosmos-kit/keplr": "npm:^2.12.2"
-    "@cosmos-kit/leap": "npm:^2.12.2"
-    "@cosmos-kit/ledger": "npm:^2.11.2"
-    "@cosmos-kit/okxwallet-extension": "npm:^2.11.2"
-    "@cosmos-kit/omni": "npm:^2.10.2"
-    "@cosmos-kit/owallet": "npm:^2.11.2"
-    "@cosmos-kit/shell": "npm:^2.11.2"
-    "@cosmos-kit/station": "npm:^2.10.2"
-    "@cosmos-kit/tailwind": "npm:^1.5.2"
-    "@cosmos-kit/trust": "npm:^2.11.2"
-    "@cosmos-kit/vectis": "npm:^2.11.2"
-    "@cosmos-kit/xdefi": "npm:^2.10.2"
-  checksum: 10c0/caa14c1c2cf0cde555e7296fc2b463d4c4183d7ee5d9c834c48e5b6399227229e343cc4ea66d722ae64b15ebc1e13d45559f695674b579f937eeb7004167170e
+    "@cosmos-kit/cdcwallet": "npm:^2.15.3"
+    "@cosmos-kit/coin98": "npm:^2.13.3"
+    "@cosmos-kit/compass": "npm:^2.13.3"
+    "@cosmos-kit/cosmostation": "npm:^2.14.2"
+    "@cosmos-kit/ctrl": "npm:^2.13.2"
+    "@cosmos-kit/exodus": "npm:^2.12.2"
+    "@cosmos-kit/fin": "npm:^2.13.3"
+    "@cosmos-kit/keplr": "npm:^2.14.3"
+    "@cosmos-kit/leap": "npm:^2.14.3"
+    "@cosmos-kit/ledger": "npm:^2.13.3"
+    "@cosmos-kit/okxwallet-extension": "npm:^2.13.1"
+    "@cosmos-kit/omni": "npm:^2.12.2"
+    "@cosmos-kit/owallet": "npm:^2.14.2"
+    "@cosmos-kit/shell": "npm:^2.13.3"
+    "@cosmos-kit/tailwind": "npm:^1.7.2"
+    "@cosmos-kit/trust": "npm:^2.13.2"
+  checksum: 10c0/11b475493c476dedbf131f8528464b35decd6ed6600d9fe69504954eb2a72d5db9e6f3caa37694950e77e9aed02cd87e057bf0fe71683f4259331db6c9664fba
   languageName: node
   linkType: hard
 
-"create-ecdh@npm:^4.0.0":
-  version: 4.0.4
-  resolution: "create-ecdh@npm:4.0.4"
-  dependencies:
-    bn.js: "npm:^4.1.0"
-    elliptic: "npm:^6.5.3"
-  checksum: 10c0/77b11a51360fec9c3bce7a76288fc0deba4b9c838d5fb354b3e40c59194d23d66efe6355fd4b81df7580da0661e1334a235a2a5c040b7569ba97db428d466e7f
-  languageName: node
-  linkType: hard
-
-"create-hash@npm:^1.1.0, create-hash@npm:^1.1.2, create-hash@npm:^1.2.0":
+"create-hash@npm:^1.1.0, create-hash@npm:^1.2.0":
   version: 1.2.0
   resolution: "create-hash@npm:1.2.0"
   dependencies:
@@ -10741,7 +10490,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-hmac@npm:^1.1.0, create-hmac@npm:^1.1.4, create-hmac@npm:^1.1.7":
+"create-hmac@npm:^1.1.7":
   version: 1.1.7
   resolution: "create-hmac@npm:1.1.7"
   dependencies:
@@ -10791,25 +10540,6 @@ __metadata:
     uWebSockets.js:
       optional: true
   checksum: 10c0/b950c64d36f3f11fdb8e0faf3107598660d89d77eb860e68b535fe6acba9f0f2f0507cc7250bd219a3ef2fe08718db91b591e6912b7324fcfc8fd1b8d9f78c96
-  languageName: node
-  linkType: hard
-
-"crypto-browserify@npm:^3.12.0":
-  version: 3.12.0
-  resolution: "crypto-browserify@npm:3.12.0"
-  dependencies:
-    browserify-cipher: "npm:^1.0.0"
-    browserify-sign: "npm:^4.0.0"
-    create-ecdh: "npm:^4.0.0"
-    create-hash: "npm:^1.1.0"
-    create-hmac: "npm:^1.1.0"
-    diffie-hellman: "npm:^5.0.0"
-    inherits: "npm:^2.0.1"
-    pbkdf2: "npm:^3.0.3"
-    public-encrypt: "npm:^4.0.0"
-    randombytes: "npm:^2.0.0"
-    randomfill: "npm:^1.0.3"
-  checksum: 10c0/0c20198886576050a6aa5ba6ae42f2b82778bfba1753d80c5e7a090836890dc372bdc780986b2568b4fb8ed2a91c958e61db1f0b6b1cc96af4bd03ffc298ba92
   languageName: node
   linkType: hard
 
@@ -10983,7 +10713,7 @@ __metadata:
     autoprefixer: "npm:^10.4.17"
     buffer: "npm:^6.0.3"
     chain-registry: "npm:1.28.0"
-    cosmos-kit: "npm:^2.19.0"
+    cosmos-kit: "npm:^2.8.5"
     daisyui: "npm:^4.12.10"
     eslint: "npm:^8.56.0"
     eslint-plugin-react-hooks: "npm:^4.6.0"
@@ -11130,13 +10860,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decimal.js@npm:^10.2.1":
-  version: 10.4.3
-  resolution: "decimal.js@npm:10.4.3"
-  checksum: 10c0/6d60206689ff0911f0ce968d40f163304a6c1bc739927758e6efc7921cfa630130388966f16bf6ef6b838cb33679fbe8e7a78a2f3c478afce841fd55ac8fb8ee
-  languageName: node
-  linkType: hard
-
 "decode-named-character-reference@npm:^1.0.0":
   version: 1.0.2
   resolution: "decode-named-character-reference@npm:1.0.2"
@@ -11222,7 +10945,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-properties@npm:^1.1.3, define-properties@npm:^1.2.0, define-properties@npm:^1.2.1":
+"define-properties@npm:^1.2.0, define-properties@npm:^1.2.1":
   version: 1.2.1
   resolution: "define-properties@npm:1.2.1"
   dependencies:
@@ -11265,16 +10988,6 @@ __metadata:
   version: 2.0.3
   resolution: "dequal@npm:2.0.3"
   checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
-  languageName: node
-  linkType: hard
-
-"des.js@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "des.js@npm:1.1.0"
-  dependencies:
-    inherits: "npm:^2.0.1"
-    minimalistic-assert: "npm:^1.0.0"
-  checksum: 10c0/671354943ad67493e49eb4c555480ab153edd7cee3a51c658082fcde539d2690ed2a4a0b5d1f401f9cde822edf3939a6afb2585f32c091f2d3a1b1665cd45236
   languageName: node
   linkType: hard
 
@@ -11351,17 +11064,6 @@ __metadata:
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: 10c0/81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
-  languageName: node
-  linkType: hard
-
-"diffie-hellman@npm:^5.0.0":
-  version: 5.0.3
-  resolution: "diffie-hellman@npm:5.0.3"
-  dependencies:
-    bn.js: "npm:^4.1.0"
-    miller-rabin: "npm:^4.0.0"
-    randombytes: "npm:^2.0.0"
-  checksum: 10c0/ce53ccafa9ca544b7fc29b08a626e23a9b6562efc2a98559a0c97b4718937cebaa9b5d7d0a05032cc9c1435e9b3c1532b9e9bf2e0ede868525922807ad6e1ecf
   languageName: node
   linkType: hard
 
@@ -11447,7 +11149,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:^6.4.0, elliptic@npm:^6.5.3, elliptic@npm:^6.5.4, elliptic@npm:^6.5.5":
+"elliptic@npm:^6.4.0, elliptic@npm:^6.5.3, elliptic@npm:^6.5.4":
   version: 6.5.5
   resolution: "elliptic@npm:6.5.5"
   dependencies:
@@ -12444,7 +12146,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:5.7.2, ethers@npm:^5.7.1, ethers@npm:^5.7.2":
+"ethers@npm:5.7.2, ethers@npm:^5.7.1":
   version: 5.7.2
   resolution: "ethers@npm:5.7.2"
   dependencies:
@@ -12500,17 +12202,6 @@ __metadata:
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: 10c0/d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
-  languageName: node
-  linkType: hard
-
-"evp_bytestokey@npm:^1.0.0, evp_bytestokey@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "evp_bytestokey@npm:1.0.3"
-  dependencies:
-    md5.js: "npm:^1.3.4"
-    node-gyp: "npm:latest"
-    safe-buffer: "npm:^5.1.1"
-  checksum: 10c0/77fbe2d94a902a80e9b8f5a73dcd695d9c14899c5e82967a61b1fc6cbbb28c46552d9b127cff47c45fcf684748bdbcfa0a50410349109de87ceb4b199ef6ee99
   languageName: node
   linkType: hard
 
@@ -13165,13 +12856,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"google-protobuf@npm:^3.17.3":
-  version: 3.21.2
-  resolution: "google-protobuf@npm:3.21.2"
-  checksum: 10c0/df20b41aad9eba4d842d69c717a4d73ac6d321084c12f524ad5eb79a47ad185323bd1b477c19565a15fd08b6eef29e475c8ac281dbc6fe547b81d8b6b99974f5
-  languageName: node
-  linkType: hard
-
 "gopd@npm:^1.0.1":
   version: 1.0.1
   resolution: "gopd@npm:1.0.1"
@@ -13274,16 +12958,6 @@ __metadata:
     readable-stream: "npm:^3.6.0"
     safe-buffer: "npm:^5.2.0"
   checksum: 10c0/663eabcf4173326fbb65a1918a509045590a26cc7e0964b754eef248d281305c6ec9f6b31cb508d02ffca383ab50028180ce5aefe013e942b44a903ac8dc80d0
-  languageName: node
-  linkType: hard
-
-"hash-base@npm:~3.0":
-  version: 3.0.4
-  resolution: "hash-base@npm:3.0.4"
-  dependencies:
-    inherits: "npm:^2.0.1"
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/a13357dccb3827f0bb0b56bf928da85c428dc8670f6e4a1c7265e4f1653ce02d69030b40fd01b0f1d218a995a066eea279cded9cec72d207b593bcdfe309c2f0
   languageName: node
   linkType: hard
 
@@ -13838,16 +13512,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-nan@npm:^1.3.2":
-  version: 1.3.2
-  resolution: "is-nan@npm:1.3.2"
-  dependencies:
-    call-bind: "npm:^1.0.0"
-    define-properties: "npm:^1.1.3"
-  checksum: 10c0/8bfb286f85763f9c2e28ea32e9127702fe980ffd15fa5d63ade3be7786559e6e21355d3625dd364c769c033c5aedf0a2ed3d4025d336abf1b9241e3d9eddc5b0
-  languageName: node
-  linkType: hard
-
 "is-negative-zero@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-negative-zero@npm:2.0.3"
@@ -14249,15 +13913,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jscrypto@npm:^1.0.1":
-  version: 1.0.3
-  resolution: "jscrypto@npm:1.0.3"
-  bin:
-    jscrypto: bin/cli.js
-  checksum: 10c0/9af6d4db4284d27a43b1228d2d510582fc650f53f6732a16a27d624c9fe28e87e68a7fde5ea2ca12c5d5748ba828715785dea75682f16781ee1e061f1faa505d
-  languageName: node
-  linkType: hard
-
 "jsdoc-type-pratt-parser@npm:~4.0.0":
   version: 4.0.0
   resolution: "jsdoc-type-pratt-parser@npm:4.0.0"
@@ -14415,18 +14070,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keccak256@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "keccak256@npm:1.0.6"
-  dependencies:
-    bn.js: "npm:^5.2.0"
-    buffer: "npm:^6.0.3"
-    keccak: "npm:^3.0.2"
-  checksum: 10c0/2a3f1e281ffd65bcbbae2ee8d62e27f0336efe6f16b7ed9932ad642ed398da62ccbc3d38dcdf43bd2fad9885f02df501dc77a900c358644df296396ed194056f
-  languageName: node
-  linkType: hard
-
-"keccak@npm:^3.0.1, keccak@npm:^3.0.2":
+"keccak@npm:^3.0.1":
   version: 3.0.4
   resolution: "keccak@npm:3.0.4"
   dependencies:
@@ -15206,18 +14850,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"miller-rabin@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "miller-rabin@npm:4.0.1"
-  dependencies:
-    bn.js: "npm:^4.0.0"
-    brorand: "npm:^1.0.1"
-  bin:
-    miller-rabin: bin/miller-rabin
-  checksum: 10c0/26b2b96f6e49dbcff7faebb78708ed2f5f9ae27ac8cbbf1d7c08f83cf39bed3d418c0c11034dce997da70d135cc0ff6f3a4c15dc452f8e114c11986388a64346
-  languageName: node
-  linkType: hard
-
 "mime-db@npm:1.52.0":
   version: 1.52.0
   resolution: "mime-db@npm:1.52.0"
@@ -15800,16 +15432,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-is@npm:^1.1.5":
-  version: 1.1.6
-  resolution: "object-is@npm:1.1.6"
-  dependencies:
-    call-bind: "npm:^1.0.7"
-    define-properties: "npm:^1.2.1"
-  checksum: 10c0/506af444c4dce7f8e31f34fc549e2fb8152d6b9c4a30c6e62852badd7f520b579c679af433e7a072f9d78eb7808d230dc12e1cf58da9154dfbf8813099ea0fe0
-  languageName: node
-  linkType: hard
-
 "object-keys@npm:^1.1.1":
   version: 1.1.1
   resolution: "object-keys@npm:1.1.1"
@@ -16121,20 +15743,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-asn1@npm:^5.0.0, parse-asn1@npm:^5.1.7":
-  version: 5.1.7
-  resolution: "parse-asn1@npm:5.1.7"
-  dependencies:
-    asn1.js: "npm:^4.10.1"
-    browserify-aes: "npm:^1.2.0"
-    evp_bytestokey: "npm:^1.0.3"
-    hash-base: "npm:~3.0"
-    pbkdf2: "npm:^3.1.2"
-    safe-buffer: "npm:^5.2.1"
-  checksum: 10c0/05eb5937405c904eb5a7f3633bab1acc11f4ae3478a07ef5c6d81ce88c3c0e505ff51f9c7b935ebc1265c868343793698fc91025755a895d0276f620f95e8a82
-  languageName: node
-  linkType: hard
-
 "parse-ms@npm:^3.0.0":
   version: 3.0.0
   resolution: "parse-ms@npm:3.0.0"
@@ -16219,19 +15827,6 @@ __metadata:
   version: 1.1.2
   resolution: "pathe@npm:1.1.2"
   checksum: 10c0/64ee0a4e587fb0f208d9777a6c56e4f9050039268faaaaecd50e959ef01bf847b7872785c36483fa5cdcdbdfdb31fef2ff222684d4fc21c330ab60395c681897
-  languageName: node
-  linkType: hard
-
-"pbkdf2@npm:^3.0.3, pbkdf2@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "pbkdf2@npm:3.1.2"
-  dependencies:
-    create-hash: "npm:^1.1.2"
-    create-hmac: "npm:^1.1.4"
-    ripemd160: "npm:^2.0.1"
-    safe-buffer: "npm:^5.0.1"
-    sha.js: "npm:^2.4.8"
-  checksum: 10c0/5a30374e87d33fa080a92734d778cf172542cc7e41b96198c4c88763997b62d7850de3fbda5c3111ddf79805ee7c1da7046881c90ac4920b5e324204518b05fd
   languageName: node
   linkType: hard
 
@@ -16716,20 +16311,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"public-encrypt@npm:^4.0.0":
-  version: 4.0.3
-  resolution: "public-encrypt@npm:4.0.3"
-  dependencies:
-    bn.js: "npm:^4.1.0"
-    browserify-rsa: "npm:^4.0.0"
-    create-hash: "npm:^1.1.0"
-    parse-asn1: "npm:^5.0.0"
-    randombytes: "npm:^2.0.1"
-    safe-buffer: "npm:^5.1.2"
-  checksum: 10c0/6c2cc19fbb554449e47f2175065d6b32f828f9b3badbee4c76585ac28ae8641aafb9bb107afc430c33c5edd6b05dbe318df4f7d6d7712b1093407b11c4280700
-  languageName: node
-  linkType: hard
-
 "pump@npm:^3.0.0":
   version: 3.0.0
   resolution: "pump@npm:3.0.0"
@@ -16846,22 +16427,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"randombytes@npm:^2.0.0, randombytes@npm:^2.0.1, randombytes@npm:^2.0.5, randombytes@npm:^2.1.0":
+"randombytes@npm:^2.1.0":
   version: 2.1.0
   resolution: "randombytes@npm:2.1.0"
   dependencies:
     safe-buffer: "npm:^5.1.0"
   checksum: 10c0/50395efda7a8c94f5dffab564f9ff89736064d32addf0cc7e8bf5e4166f09f8ded7a0849ca6c2d2a59478f7d90f78f20d8048bca3cdf8be09d8e8a10790388f3
-  languageName: node
-  linkType: hard
-
-"randomfill@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "randomfill@npm:1.0.4"
-  dependencies:
-    randombytes: "npm:^2.0.5"
-    safe-buffer: "npm:^5.1.0"
-  checksum: 10c0/11aeed35515872e8f8a2edec306734e6b74c39c46653607f03c68385ab8030e2adcc4215f76b5e4598e028c4750d820afd5c65202527d831d2a5f207fe2bc87c
   languageName: node
   linkType: hard
 
@@ -17100,7 +16671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.8":
+"readable-stream@npm:^2.3.3":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
   dependencies:
@@ -17485,7 +17056,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:^5.1.1, safe-buffer@npm:^5.1.2, safe-buffer@npm:^5.2.0, safe-buffer@npm:^5.2.1, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:^5.1.2, safe-buffer@npm:^5.2.0, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
@@ -17546,18 +17117,6 @@ __metadata:
   version: 3.0.1
   resolution: "scrypt-js@npm:3.0.1"
   checksum: 10c0/e2941e1c8b5c84c7f3732b0153fee624f5329fc4e772a06270ee337d4d2df4174b8abb5e6ad53804a29f53890ecbc78f3775a319323568c0313040c0e55f5b10
-  languageName: node
-  linkType: hard
-
-"secp256k1@npm:^4.0.2":
-  version: 4.0.3
-  resolution: "secp256k1@npm:4.0.3"
-  dependencies:
-    elliptic: "npm:^6.5.4"
-    node-addon-api: "npm:^2.0.0"
-    node-gyp: "npm:latest"
-    node-gyp-build: "npm:^4.2.0"
-  checksum: 10c0/de0a0e525a6f8eb2daf199b338f0797dbfe5392874285a145bb005a72cabacb9d42c0197d0de129a1a0f6094d2cc4504d1f87acb6a8bbfb7770d4293f252c401
   languageName: node
   linkType: hard
 
@@ -19036,7 +18595,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"utf-8-validate@npm:^5.0.2, utf-8-validate@npm:^5.0.5":
+"utf-8-validate@npm:^5.0.2":
   version: 5.0.10
   resolution: "utf-8-validate@npm:5.0.10"
   dependencies:
@@ -19053,7 +18612,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util@npm:^0.12.4, util@npm:^0.12.5":
+"util@npm:^0.12.4":
   version: 0.12.5
   resolution: "util@npm:0.12.5"
   dependencies:
@@ -19526,7 +19085,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^7, ws@npm:^7.2.0, ws@npm:^7.4.5, ws@npm:^7.5.1, ws@npm:^7.5.9":
+"ws@npm:^7, ws@npm:^7.2.0, ws@npm:^7.4.5, ws@npm:^7.5.1":
   version: 7.5.9
   resolution: "ws@npm:7.5.9"
   peerDependencies:


### PR DESCRIPTION
Closes: https://github.com/Agoric/dapp-orchestration-basics/issues/98

This PR attempts to unbreak `main` by downgrading cosmos-kit to 2.8.5 as suggested by [ui-tutorial repo](https://github.com/agoric-labs/ui-tutorial/blob/f6298419ac6237de5d4b49b1bb6f2847b41fcd2c/package.json#L26)